### PR TITLE
featherdoc comment in the main scribble() function

### DIFF
--- a/scripts/scribble/scribble.gml
+++ b/scripts/scribble/scribble.gml
@@ -1,7 +1,7 @@
 /// Returns a Scribble text element corresponding to the input string
 /// If a text element with the same input string (and unique ID) has been cached, this function will return the cached text element
 /// 
-/// @param string       The string to parse and, eventually, draw
+/// @param {String} string       The string to parse and, eventually, draw
 /// @param [uniqueID]   A unique identifier that can be used to distinguish this occurrence of the input string from other occurrences. Only necessary when you might be drawing the same string at the same time with different animation states
 
 function scribble(_string, _unique_id = undefined)


### PR DESCRIPTION
because the first thing in the `scribble()` function is a check if the argument is a struct, feather thinks the argument is supposed to be a struct, and will yell at you whenever you try to pass it a string the way it's supposed to; with stock feather settings that currently accounts for 300ish of the 400ish "errors" in the main branch of the repository