### PR TITLE
Struct was being called call on ds_map function

### DIFF
--- a/scripts/scribble_typists_add_event/scribble_typists_add_event.gml
+++ b/scripts/scribble_typists_add_event/scribble_typists_add_event.gml
@@ -31,7 +31,7 @@ function scribble_typists_add_event(_name, _function)
         }
     }
     
-    if (ds_map_exists(__scribble_config_colours(), _name))
+    if (variable_struct_exists(__scribble_config_colours(), _name))
     {
         __scribble_trace("Warning! Event name \"" + _name + "\" has already been defined as a colour");
         exit;


### PR DESCRIPTION
In regards to scribble typist event adding: 
ds_map_exists was being called on a struct. Changed to proper exists check for struct type.