### PR TITLE
Swapped the locations of scribble_external_sound_exists and scribble_external_sound_remove functions so that they are in the scripts with the same name

### DIFF
--- a/scripts/scribble_external_sound_exists/scribble_external_sound_exists.gml
+++ b/scripts/scribble_external_sound_exists/scribble_external_sound_exists.gml
@@ -1,4 +1,4 @@
-function scribble_external_sound_remove(_alias)
+function scribble_external_sound_exists(_alias)
 {
-    ds_map_delete(__scribble_get_external_sound_map(), _alias);
+    return ds_map_exists(__scribble_get_external_sound_map(), _alias);
 }

--- a/scripts/scribble_external_sound_remove/scribble_external_sound_remove.gml
+++ b/scripts/scribble_external_sound_remove/scribble_external_sound_remove.gml
@@ -1,4 +1,4 @@
-function scribble_external_sound_exists(_alias)
+function scribble_external_sound_remove(_alias)
 {
-    return ds_map_exists(__scribble_get_external_sound_map(), _alias);
+    ds_map_delete(__scribble_get_external_sound_map(), _alias);
 }


### PR DESCRIPTION
The function "scribble_external_sound_exists" was in the script "scribble_external_sound_remove", and vice versa. Having them backwards made scribble unable to compile in the latest 2024.2 beta, swapping them fixes that and lets scribble compile.