### PR TITLE
Now scans for all project fonts using asset_get_ids

### DIFF
--- a/scripts/__scribble_font_add_all_from_project/__scribble_font_add_all_from_project.gml
+++ b/scripts/__scribble_font_add_all_from_project/__scribble_font_add_all_from_project.gml
@@ -1,20 +1,23 @@
 // Feather disable all
+
 function __scribble_font_add_all_from_project()
 {
     //Try to add all fonts in the project to Scribble
-    var _fonts = asset_get_ids(asset_font);
-	
-	for (var _i=0, _n=array_length(_fonts); _i<_n; _i++) {
-	
-        if (!font_exists(_fonts[_i])) break;
+    var _fontArray = asset_get_ids(asset_font);
+    
+    var _i = 0;
+    repeat(array_length(_fontArray))
+    {
+        var _font = _fontArray[_i];
+        if (not font_exists(_font)) continue;
         
         var _skip = false;
         
-        var _tags = asset_get_tags(_fonts[_i], asset_font);
+        var _tagArray = asset_get_tags(_fontArray[_i], asset_font);
         var _j = 0;
-        repeat(array_length(_tags))
+        repeat(array_length(_tagArray))
         {
-            if (string_lower(_tags[_j]) == "scribble skip")
+            if (string_lower(_tagArray[_j]) == "scribble skip")
             {
                 _skip = true;
                 break;
@@ -23,16 +26,17 @@ function __scribble_font_add_all_from_project()
             ++_j;
         }
         
-        var _name = font_get_name(_fonts[_i]);
+        var _name = font_get_name(_fontArray[_i]);
         if (string_copy(_name, 1, 9) == "__newfont") //Don't scan fonts created at runtime (e.g. by font_add_sprite())
         {
             _skip = true;
         }
         
-        if (!_skip)
+        if (not _skip)
         {
-            __scribble_font_add_from_project(_fonts[_i]);
+            __scribble_font_add_from_project(_fontArray[_i]);
         }
-    
+        
+        ++_i;
     }
 }

--- a/scripts/__scribble_font_add_all_from_project/__scribble_font_add_all_from_project.gml
+++ b/scripts/__scribble_font_add_all_from_project/__scribble_font_add_all_from_project.gml
@@ -2,14 +2,15 @@
 function __scribble_font_add_all_from_project()
 {
     //Try to add all fonts in the project to Scribble
-    var _i = 0;
-    repeat(1000)
-    {
-        if (!font_exists(_i)) break;
+    var _fonts = asset_get_ids(asset_font);
+	
+	for (var _i=0, _n=array_length(_fonts); _i<_n; _i++) {
+	
+        if (!font_exists(_fonts[_i])) break;
         
         var _skip = false;
         
-        var _tags = asset_get_tags(_i, asset_font);
+        var _tags = asset_get_tags(_fonts[_i], asset_font);
         var _j = 0;
         repeat(array_length(_tags))
         {
@@ -22,7 +23,7 @@ function __scribble_font_add_all_from_project()
             ++_j;
         }
         
-        var _name = font_get_name(_i);
+        var _name = font_get_name(_fonts[_i]);
         if (string_copy(_name, 1, 9) == "__newfont") //Don't scan fonts created at runtime (e.g. by font_add_sprite())
         {
             _skip = true;
@@ -30,9 +31,8 @@ function __scribble_font_add_all_from_project()
         
         if (!_skip)
         {
-            __scribble_font_add_from_project(_i);
+            __scribble_font_add_from_project(_fonts[_i]);
         }
     
-        ++_i;
     }
 }


### PR DESCRIPTION
The function `__scribble_font_add_all_from_project()` used to scan fonts by using a numeric integer from 0 to 999 and checking whether the font with that index exists. However since typed references exist this should not work. At least in GRMT this does indeed not work and it complains about submitting an integer, not a font reference, to `font_exists()`. So the commit is about using the `asset_get_ids()` function to get all fonts in an array and process them.