### PR TITLE
Fix for valign font offset issue in __scribble_gen_2_parser.gml

### DIFF
--- a/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
+++ b/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
@@ -78,7 +78,7 @@
                                     var _font_valign_offset_array = _font_data.__valign_offset_array;\
                                     ;\
                                     var _state_halign_offset = _font_halign_offset_array[_state_halign];\
-                                    var _state_valign_offset = _font_halign_offset_array[__valign ?? _starting_valign];\
+                                    var _state_valign_offset = _font_valign_offset_array[__valign ?? _starting_valign];\
                                     ;\
                                     var _space_data_index     = _font_glyphs_map[? 32];\
                                     if (_space_data_index == undefined)\


### PR DESCRIPTION
Fix for the bug listed here: https://github.com/JujuAdams/Scribble/issues/539

var _state_valign_offset was using the _font_halign_offset_array which caused any valign settings to be ignored and halign settings to be used in their place when using font alignment offsets.