### PR TITLE
Fix align function

### DIFF
--- a/scripts/__scribble_class_element/__scribble_class_element.gml
+++ b/scripts/__scribble_class_element/__scribble_class_element.gml
@@ -246,7 +246,7 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     /// @param halign
     /// @param valign
-    static align = function(_halign, _valign)
+    static align = function(_halign = __starting_halign, _valign = __starting_valign)
     {
         if (_halign == "pin_left"  ) _halign = __SCRIBBLE_PIN_LEFT;
         if (_halign == "pin_centre") _halign = __SCRIBBLE_PIN_CENTRE;


### PR DESCRIPTION
Align function was allowing the starting alignment state to be set to undefined, which is later used to attempt to access an array index, causing crashes. Intention appears to allow for undefined values, so some sort of handling should likely be done. From what I can intuit, this appears as if it would be the preferred way to handle this sort of input to this function.

Submitting as a draft PR for now to discuss whether this is in fact the intended way of resolving this issue, but will close #545 if accepted.