### PR TITLE
fix @param in scribble text element

### DIFF
--- a/scripts/scribble/scribble.gml
+++ b/scripts/scribble/scribble.gml
@@ -2,7 +2,7 @@
 /// Returns a Scribble text element corresponding to the input string
 /// If a text element with the same input string (and unique ID) has been cached, this function will return the cached text element
 /// 
-/// @param string       The string to parse and, eventually, draw
+/// @param {string}     The string to parse and, eventually, draw
 /// @param [uniqueID]   A unique identifier that can be used to distinguish this occurrence of the input string from other occurrences. Only necessary when you might be drawing the same string at the same time with different animation states
 
 function scribble(_string, _unique_id = undefined)


### PR DESCRIPTION
This adds curly brackets around the variable type `string` in a `scribble()` function header `@param`, preventing an error reported by Feather.

```
E GM1041 The type 'String' appears where the type 'Struct' is expected. Object1 : Create 12:21
```