### PR TITLE
Fix - Texture Compare Using Pointers Causing Batch Breaks

### DIFF
--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = font_get_texture(_asset);
+        var _texture     = font_get_info(_asset).texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID -Red (2025/03/23)
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = __scribble_font_get_texture_id(_asset);
+        var _texture     = __scribble_font_get_texture(_asset);
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = font_get_info(_asset).texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID -Red (2025/03/23)
+        var _texture     = __scribble_font_get_texture_id(_asset);
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_sprite/__scribble_font_add_sprite.gml
+++ b/scripts/__scribble_font_add_sprite/__scribble_font_add_sprite.gml
@@ -129,16 +129,7 @@ function __scribble_font_add_sprite_common(_sprite, _spritefont, _proportional, 
         {
             var _image_info = _sprite_frames[_image];
             
-            //Convert the texture index to a texture pointer
-            var _texture_index = _image_info.texture;
-            
-            static _tex_index_lookup_map = ds_map_create();
-            var _texture = _tex_index_lookup_map[? _texture_index];
-            if (_texture == undefined)
-            {
-                _texture = sprite_get_texture(_sprite, _image);
-                _tex_index_lookup_map[? _texture_index] = _texture;
-            }
+            var _texture = __scribble_sprite_get_texture(_sprite, _image)
             
             if (_proportional)
             {

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = __scribble_sprite_get_texture_id(_sprite_index, _j);
+                    var _glyph_texture = __scribble_sprite_get_texture(_sprite_index, _j);
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = sprite_get_info(_sprite_index).frames[_j].texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID
+                    var _glyph_texture = __scribble_sprite_get_texture_id(_sprite_index, _j);
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = sprite_get_texture(_sprite_index, _j);
+                    var _glyph_texture = sprite_get_info(_sprite_index).frames[_j].texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -362,7 +362,7 @@ function __scribble_matrix_inverse(_matrix)
 function __scribble_sprite_get_texture(_sprite_index, _image_index)
 {
 	static __texture_id_lookup = ds_map_create();
-	static __texture_pointer_lookup = ds_map_create();
+	static __texture_pointer_lookup = __scribble_texture_pointer_lookup();
 	
 	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index);
 	var _texture_id = __texture_id_lookup[? _key];
@@ -376,7 +376,7 @@ function __scribble_sprite_get_texture(_sprite_index, _image_index)
 	if (_pointer == undefined)
 	{
 		_pointer = sprite_get_texture(_sprite_index, _image_index);
-		__texture_pointer_lookup[? _key] = _texture_id;
+		__texture_pointer_lookup[? _texture_id] = _pointer;
 	}
 	
 	return _pointer;
@@ -385,7 +385,7 @@ function __scribble_sprite_get_texture(_sprite_index, _image_index)
 function __scribble_font_get_texture(_font)
 {
 	static __texture_id_lookup = ds_map_create();
-	static __texture_pointer_lookup = ds_map_create();
+	static __texture_pointer_lookup = __scribble_texture_pointer_lookup();
 	
 	var _key = font_get_name(_font);
 	var _texture_id = __texture_id_lookup[? _key];
@@ -399,11 +399,18 @@ function __scribble_font_get_texture(_font)
 	if (_pointer == undefined)
 	{
 		_pointer = font_get_texture(_font);
-		__texture_pointer_lookup[? _key] = _texture_id;
+		__texture_pointer_lookup[? _texture_id] = _pointer;
 	}
 	
 	return _pointer;
 }
+
+function __scribble_texture_pointer_lookup()
+{
+	static __texture_pointer_lookup = ds_map_create();
+	return __texture_pointer_lookup;
+}
+
 
 #region Enums
 

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -359,49 +359,50 @@ function __scribble_matrix_inverse(_matrix)
     return _inv;
 }
 
-function __scribble_sprite_get_texture_id(_sprite_index, _image_index)
+function __scribble_sprite_get_texture(_sprite_index, _image_index)
 {
-	static __cache = {}
+	static __texture_id_lookup = ds_map_create();
+	static __texture_pointer_lookup = ds_map_create();
 	
-	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index)
-	var _val = __cache[$ _key];
-	if (_val != undefined)
+	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index);
+	var _texture_id = __texture_id_lookup[? _key];
+	if (_texture_id == undefined)
 	{
-		return _val;
+		_texture_id = sprite_get_info(_sprite_index).frames[_image_index].texture;
+		__texture_id_lookup[? _key] = _texture_id;
 	}
 	
-	if (__SCRIBBLE_ON_WEB) {
-		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
-		_val = sprite_get_texture(_sprite_index, _image_index);
+	var _pointer = __texture_pointer_lookup[? _texture_id];
+	if (_pointer == undefined)
+	{
+		_pointer = sprite_get_texture(_sprite_index, _image_index);
+		__texture_pointer_lookup[? _key] = _texture_id;
 	}
-	else {
-		_val = sprite_get_info(_sprite_index).frames[_image_index].texture;
-	}
-	__cache[$ _key] = _val;
 	
-	return _val;
+	return _pointer;
 }
-function __scribble_font_get_texture_id(_font)
+
+function __scribble_font_get_texture(_font)
 {
-	static __cache = {}
+	static __texture_id_lookup = ds_map_create();
+	static __texture_pointer_lookup = ds_map_create();
 	
-	var _key = font_get_name(_font)
-	var _val = __cache[$ _key];
-	if (_val != undefined)
+	var _key = font_get_name(_font);
+	var _texture_id = __texture_id_lookup[? _key];
+	if (_texture_id == undefined)
 	{
-		return _val;
+		_texture_id = font_get_info(_font).texture;
+		__texture_id_lookup[? _key] = _texture_id;
 	}
 	
-	if (__SCRIBBLE_ON_WEB) {
-		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
-		_val = font_get_texture(_font);
+	var _pointer = __texture_pointer_lookup[? _texture_id];
+	if (_pointer == undefined)
+	{
+		_pointer = font_get_texture(_font);
+		__texture_pointer_lookup[? _key] = _texture_id;
 	}
-	else {
-		_val = font_get_info(_font).texture;
-	}
-	__cache[$ _key] = _val;
 	
-	return _val;
+	return _pointer;
 }
 
 #region Enums

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -359,6 +359,51 @@ function __scribble_matrix_inverse(_matrix)
     return _inv;
 }
 
+function __scribble_sprite_get_texture_id(_sprite_index, _image_index)
+{
+	static __cache = {}
+	
+	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index)
+	var _val = __cache[$ _key];
+	if (_val != undefined)
+	{
+		return _val;
+	}
+	
+	if (__SCRIBBLE_ON_WEB) {
+		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
+		_val = sprite_get_texture(_sprite_index, _image_index);
+	}
+	else {
+		_val = sprite_get_info(_sprite_index).frames[_image_index].texture;
+	}
+	__cache[$ _key] = _val;
+	
+	return _val;
+}
+function __scribble_font_get_texture_id(_font)
+{
+	static __cache = {}
+	
+	var _key = font_get_name(_font)
+	var _val = __cache[$ _key];
+	if (_val != undefined)
+	{
+		return _val;
+	}
+	
+	if (__SCRIBBLE_ON_WEB) {
+		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
+		_val = font_get_texture(_font);
+	}
+	else {
+		_val = font_get_info(_font).texture;
+	}
+	__cache[$ _key] = _val;
+	
+	return _val;
+}
+
 #region Enums
 
 enum __SCRIBBLE_GLYPH_LAYOUT

--- a/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
+++ b/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
@@ -90,12 +90,14 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
         
         //Ignore any glyphs with invalid textures
         //Due to HTML5 being dogshit, we can't use is_ptr()
-        if (is_numeric(_texture) || is_undefined(_texture))
-        {
+		// Expect numeric texture ID for non html platforms
+		if (is_undefined(_texture))
+        || (__SCRIBBLE_ON_WEB && is_numeric(_texture))
+		{
             ++_i;
             continue;
         }
-        
+		
         var _width_ext  = _width  + _outline + _l_pad + _r_pad;
         var _height_ext = _height + _outline + _t_pad + _b_pad;
         
@@ -223,8 +225,6 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     _new_font_data.__source_sprite = _sprite;
     surface_free(_surface_1);
     
-    
-    
     //Make bulk corrections to various glyph properties based on the input parameters
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.X_OFFSET,    _glyph_count-1, SCRIBBLE_GLYPH.X_OFFSET,    -_l_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.Y_OFFSET,    _glyph_count-1, SCRIBBLE_GLYPH.Y_OFFSET,    -_t_pad);
@@ -232,7 +232,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.HEIGHT,      _glyph_count-1, SCRIBBLE_GLYPH.HEIGHT,      _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_HEIGHT, _glyph_count-1, SCRIBBLE_GLYPH.FONT_HEIGHT, _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.SEPARATION,  _glyph_count-1, SCRIBBLE_GLYPH.SEPARATION,  _separation);
-    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     sprite_get_texture(_sprite, 0));
+    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture_id(_sprite, 0));
     ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_NAME,   _glyph_count-1, SCRIBBLE_GLYPH.FONT_NAME,   _new_font_name);
     
     //Figure out the new UVs using some bulk commands

--- a/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
+++ b/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
@@ -90,9 +90,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
         
         //Ignore any glyphs with invalid textures
         //Due to HTML5 being dogshit, we can't use is_ptr()
-		// Expect numeric texture ID for non html platforms
-		if (is_undefined(_texture))
-        || (__SCRIBBLE_ON_WEB && is_numeric(_texture))
+		if (is_numeric(_texture) || is_undefined(_texture))
 		{
             ++_i;
             continue;
@@ -232,7 +230,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.HEIGHT,      _glyph_count-1, SCRIBBLE_GLYPH.HEIGHT,      _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_HEIGHT, _glyph_count-1, SCRIBBLE_GLYPH.FONT_HEIGHT, _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.SEPARATION,  _glyph_count-1, SCRIBBLE_GLYPH.SEPARATION,  _separation);
-    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture_id(_sprite, 0));
+    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture(_sprite, 0));
     ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_NAME,   _glyph_count-1, SCRIBBLE_GLYPH.FONT_NAME,   _new_font_name);
     
     //Figure out the new UVs using some bulk commands


### PR DESCRIPTION
There was a bug where two sprites on the same atlas would produce 2 different pointers, despite the fact they were on the same Texture page this would cause for an unneeded batch break. This is because `sprite_get_texture` will return a unique reference for every frame of an image.
I've converted sprite and front texture look ups to make use texture IDs instead, it is worth noting html5 does not currently support texture IDs as a replacement to texture page pointers, but all other platforms should.