### PR TITLE
Improved jsDocs

### DIFF
--- a/scripts/GlyphArrayBiDiReorder/GlyphArrayBiDiReorder.gml
+++ b/scripts/GlyphArrayBiDiReorder/GlyphArrayBiDiReorder.gml
@@ -1,6 +1,6 @@
-/// @param glyphArray
-/// @param rightToLeftHint
-/// @param [copy=true]
+/// @param {Array} glyphArray
+/// @param {Bool} rightToLeftHint
+/// @param {Bool} [copy=true]
 
 function GlyphArrayBiDiReorder(_glyphArray, _rightToLeftHint, _copy = true)
 {

--- a/scripts/StringArabicParse/StringArabicParse.gml
+++ b/scripts/StringArabicParse/StringArabicParse.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param string
+/// @param {String} string
 
 function StringArabicParse(_string)
 {

--- a/scripts/StringDevanagariParse/StringDevanagariParse.gml
+++ b/scripts/StringDevanagariParse/StringDevanagariParse.gml
@@ -50,7 +50,7 @@
 /// 4) Setting Krutidev font glyph ranges is a faff. Not the worst thing in the world, but worth
 ///    bearing in mind.
 /// 
-/// @param unicodeString
+/// @param {String} unicodeString
 
 function StringDevanagariParse(_inString)
 {

--- a/scripts/__scribble_class_element/__scribble_class_element.gml
+++ b/scripts/__scribble_class_element/__scribble_class_element.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param string
-/// @param uniqueID
+/// @param {String} string
+/// @param {String} uniqueID
 
 function __scribble_class_element(_string, _unique_id) constructor
 {
@@ -155,9 +155,10 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Basics
     
-    /// @param x
-    /// @param y
-    /// @param [typist]
+    /// @param {real} x							x position in the room to draw at
+    /// @param {real} y							y position in the room to draw at
+    /// @param {Id.Scribble.typist} [typist]	Optional. Typist being used to render the text element. See scribble_typist() for more information.
+	/// @returns {Id.Scribble.element}
     static draw = function(_x, _y, _typist = undefined)
     {
         static _scribble_state = __scribble_initialize().__state;
@@ -218,8 +219,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         }
     }
     
-    /// @param fontName
-    /// @param colour
+    /// @param {string} fontName						Name of the starting font, as a string. This is the font that is set when [/] or [/font] is used in a string
+    /// @param {Real.Int|Constant.Colour} colour	Starting colour in the standard GameMaker 24-bit BGR format. This is the colour that is set when [/] or [/color] is used in a string
+	/// @returns {Id.Scribble.element}
     static starting_format = function(_font_name, _in_colour)
     {
         if (is_string(_font_name))
@@ -248,8 +250,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param halign
-    /// @param valign
+    /// @param {Constant.HAlign} halign		Starting horizontal alignment of each line of text. Accepts fa_left, fa_right, and fa_center
+    /// @param {Constant.VAlign} valign		Starting vertical alignment of the entire textbox. Accepts fa_top, fa_bottom, and fa_middle
+	/// @returns {Id.Scribble.element}
     static align = function(_halign = __starting_halign, _valign = __starting_valign)
     {
         if (_halign == "pin_left"  ) _halign = __SCRIBBLE_PIN_LEFT;
@@ -277,8 +280,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param colour
-    /// @param alpha
+    /// @param {Real.Int|Constant.Colour} colour	Blend colour used when drawing text, applied multiplicatively
+    /// @param {Real.Float} alpha						Alpha used when drawing text, 0 being fully transparent and 1 being fully opaque
+	/// @returns {Id.Scribble.element}
     static blend = function(_colour, _alpha)
     {
         static _colors_struct = __scribble_config_colours();
@@ -299,8 +303,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param colour
-    /// @param alpha
+    /// @param {Real.Int|Constant.Colour} colour	Colour of the bottom of the gradient for each glyph
+    /// @param {Real.Float} alpha						Blending factor for the gradient, from 0 (no gradient applied) to 1 (base blend colour of the bottom of each glyph is replaced with colour)
+	/// @returns {Id.Scribble.element}
     static gradient = function(_colour, _alpha)
     {
         static _colors_struct = __scribble_config_colours();
@@ -320,13 +325,15 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @desc	.fog() has been replaced by .flash()
     static fog = function()
     {
         __scribble_error(".fog() has been replaced by .flash()");
     }
     
-    /// @param colour
-    /// @param alpha
+    /// @param {Real.Int|Constant.Colour} colour	Flash colour, in the standard GameMaker 24-bit BGR format
+    /// @param {Real.Float} alpha						Blending factor for the flash, from 0 to 1
+	/// @returns {Id.Scribble.element}
     static flash = function(_colour, _alpha)
     {
         static _colors_struct = __scribble_config_colours();
@@ -352,8 +359,9 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Layout
     
-    /// @param xOffset
-    /// @param yOffset
+    /// @param {real} xOffset	x-coordinate of the origin, in model space
+    /// @param {real} yOffset	y-coordinate of the origin, in model space
+	/// @returns {Id.Scribble.element}
     static origin = function(_x, _y)
     {
         if ((__origin_x != _x) || (__origin_y != _y))
@@ -368,9 +376,10 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param xScale
-    /// @param [yScale=xScale]
-    /// @param [angle=0]
+    /// @param {Real} xscale			x scale of the text element
+    /// @param {Real} [yScale=xScale]	y scale of the text element
+    /// @param {Real} [angle=0]		rotation angle of the text element
+	/// @returns {Id.Scribble.element}
     static transform = function(_xscale, _yscale = _xscale, _angle = 0)
     {
         if ((__post_xscale != _xscale) || (__post_yscale != _yscale) || (__post_angle != _angle))
@@ -386,7 +395,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param scale
+    /// @param {Real} scale		Scaling factor to apply to the text element. 1.0 represents no change in scale
+	/// @returns {Id.Scribble.element}
     static scale = function(_scale)
     {
         if (__pre_scale != _scale)
@@ -400,6 +410,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real} skewX		Skew factor contributed by x-coordinate of glyphs in the text element. A value is 0 confers no skewing
+    /// @param {Real} skewY		Skew factor contributed by y-coordinate of glyphs in the text element. A value of 0 confers no skewing
+    /// @returns {Id.Scribble.element}
     static skew = function(_skew_x, _skew_y)
     {
         __skew_x = _skew_x;
@@ -408,9 +421,10 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param maxWidth
-    /// @param maxHeight
-    /// @param [maximise=false]
+    /// @param {Real} maxWidth			Maximum width of the bounding box to fit the text into. Use a negative number (the default) for no limit
+    /// @param {Real} maxHeight			Maximum height of the bounding box to fit the text into. Use a negative number (the default) for no limit
+    /// @param {Bool} [maximise=false]	Allows the scaling algorithm to increase the scale as well as decreasing. Defaults to false
+	/// @returns {Id.Scribble.element}
     static scale_to_box = function(_max_width, _max_height, _maximise = false)
     {
         _max_width  = ((_max_width  == undefined) || (_max_width  < 0))? 0 : _max_width;
@@ -427,9 +441,10 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param maxWidth
-    /// @param [maxHeight=-1]
-    /// @param [characterWrap=false]
+    /// @param {Real.Int} maxWidth				Maximum width for the whole textbox. Use a negative number (the default) for no limit
+    /// @param {Real.Int} [maxHeight=-1]		Maximum height for the whole textbox. Use a negative number (the default) for no limit
+    /// @param {Bool} [characterWrap=false]	Whether to wrap text per character (rather than per word). Defaults to false. This is useful for tight textboxes and some East Asian languages
+	/// @returns {Id.Scribble.element}
     static wrap = function(_wrap_max_width, _wrap_max_height = -1, _wrap_per_char = false)
     {
         if (!__wrap_apply
@@ -454,10 +469,11 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param maxWidth
-    /// @param maxHeight
-    /// @param [characterWrap=false]
-    /// @param [maxScale=1]
+    /// @param {Real.Int} maxWidth			Maximum width for the whole textbox
+    /// @param {Real.Int} maxHeight			Maximum height for the whole textbox
+    /// @param {Bool} [characterWrap=false]	Whether to wrap text per character (rather than per word). Defaults to false. This is useful for very tight textboxes and some East Asian languages
+    /// @param {Real} [maxScale=1]			
+	/// @returns {Id.Scribble.element}
     static fit_to_box = function(_wrap_max_width, _wrap_max_height, _wrap_per_char = false, _wrap_max_scale = 1)
     {
         if (!__wrap_apply
@@ -483,6 +499,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real.Int} width		Width to use for pin-type alignments. Use a negative number (the default) to use the width of the text instead of a fixed number
+    /// @returns {Id.Scribble.element}
     static pin_guide_width = function(_width)
     {
         if (__wrap_apply
@@ -507,8 +525,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param min
-    /// @param max
+    /// @param {Real} min	Minimum line height for each line of text. Use a negative number (the default) for the height of a space character of the default font
+    /// @param {Real} max	Maximum line height for each line of text. Use a negative number (the default) for no limit
+	/// @returns {Id.Scribble.element}
     static line_height = function(_min, _max)
     {
         if (_min != __line_height_min)
@@ -526,7 +545,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param spacing
+    /// @param {Real|String} spacing	The spacing from one line of text to the next. Can be a number, or a percentage string e.g. "100%"
+	/// @returns {Id.Scribble.element}
     static line_spacing = function(_spacing)
     {
         if (_spacing != __line_spacing)
@@ -538,6 +558,11 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real} left		Extra space on the left-hand side of the textbox. Positive values create more space
+	/// @param {Real} top		Extra space on the top of the textbox. Positive values create more space
+	/// @param {Real} right		Extra space on the right-hand side of the textbox. Positive values create more space
+	/// @param {Real} bottom	Extra space on the bottom of the textbox. Positive values create more space
+	/// @returns {Id.Scribble.element}
     static padding = function(_l, _t, _r, _b)
     {
         if ((_l != __padding_l) || (_t != __padding_t) || (_r != __padding_r) || (_b != __padding_b))
@@ -556,14 +581,15 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param [x1=0]
-    /// @param [y1=0]
-    /// @param [x2=0]
-    /// @param [y2=0]
-    /// @param [x3=0]
-    /// @param [y3=0]
-    /// @param [x4=0]
-    /// @param [y4=0]
+    /// @param {Real} [x1=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [y1=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [x2=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [y2=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [x3=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [y3=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [x4=0]	Parameter for the cubic Bézier curve
+    /// @param {Real} [y4=0]	Parameter for the cubic Bézier curve
+	/// @returns {Id.Scribble.element}
     static bezier = function(_x1, _y1, _x2, _y2, _x3, _y3, _x4, _y4)
     {
         if (argument_count <= 0)
@@ -608,6 +634,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Bool} state		Whether the overall text direction is right-to-left
+	/// @returns {Id.Scribble.element}
     static right_to_left = function(_state)
     {
         if (_state == undefined)
@@ -634,6 +662,12 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Regions
     
+	
+	/// @param {Real} elementX	x position of the text element in the room (usually the same as the coordinate you’d specify for .draw())
+	/// @param {Real} elementY	y position of the text element in the room (usually the same as the coordinate you’d specify for .draw())
+	/// @param {Real} pointerX	x position of the mouse/cursor
+	/// @param {Real} pointerY	y position of the mouse/cursor
+	/// @return {String}
     static region_detect = function(_element_x, _element_y, _pointer_x, _pointer_y)
     {
         var _model = __get_model(true);
@@ -675,6 +709,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _found;
     }
     
+	/// @param {String}		name		Name of the region to highlight. Use undefined to highlight no region
+	/// @param {Real.Int}	colour		Colour to highlight the region (a standard GameMaker BGR colour)
+	/// @param {Real}		blendAmount	Blend factor to apply for the highlighted region
     static region_set_active = function(_name, _colour, _blend_amount)
     {
         if (!is_string(_name))
@@ -713,17 +750,20 @@ function __scribble_class_element(_string, _unique_id) constructor
         __scribble_error("Region \"", _name, "\" not found");
     }
     
+	/// @returns {String}
     static region_get_active = function()
     {
         return __region_active;
     }
     
+	/// @returns {Id.Scribble.element}
     static region_clear = function()
     {
         region_set_active(undefined, undefined, undefined);
         return self;
     }
     
+	/// @returns {Array<Struct>}
     static region_get_bboxes = function()
     {
         static _emptyArray = [];
@@ -855,8 +895,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return __bbox_raw_height;
     }
     
-    /// @param x
-    /// @param y
+    /// @param {real} x
+    /// @param {real} y
     static get_bbox = function(_x = 0, _y = 0)
     {
         __update_bbox_matrix();
@@ -880,9 +920,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         };
     }
     
-    /// @param x
-    /// @param y
-    /// @param [typist]
+    /// @param {real} x
+    /// @param {real} y
+    /// @param {Id.Scribble.typist} [typist]
     static get_bbox_revealed = function(_x, _y, _typist)
     {
         //No typist set up, return the whole bounding box
@@ -977,7 +1017,8 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Pages
     
-    /// @param page
+    /// @param {Real.Int} page	Page to display, starting at 0 for the first page
+	/// @returns {Id.Scribble.element}
     static page = function(_page)
     {
         var _old_page = __page;
@@ -1010,16 +1051,19 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @returns {Real.Int}
     static get_page = function()
     {
         return __page;
     }
     
+	/// @desc .get_pages() has been replaced by .get_page_count()
     static get_pages = function()
     {
         __scribble_error(".get_pages() has been replaced by .get_page_count()");
     }
     
+	/// @returns {Real.Int}
     static get_page_count = function()
     {
         var _model = __get_model(true);
@@ -1027,6 +1071,7 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__get_page_count();
     }
     
+	/// @returns {Bool}
     static on_last_page = function()
     {
         return (get_page() >= get_page_count() - 1);
@@ -1038,6 +1083,7 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Other Getters
     
+	/// @return {Bool}
     static get_wrapped = function()
     {
         var _model = __get_model(true);
@@ -1045,7 +1091,7 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__get_wrapped();
     }
     
-    /// @param [page]
+    /// @return {String}
     static get_text = function()
     {
         var _page = ((argument_count > 0) && (argument[0] != undefined))? argument[0] : __page;
@@ -1055,7 +1101,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__get_text(_page);
     }
     
-    /// @param [page]
+	/// @param {Real.Int} glyphIndex	integer	Index of the glyph whose data will be returned
+	/// @param {Real.Int} [page]		integer	Page to get the glyph data from. If not specified, the current page is used
+	/// @return {Struct}
     static get_glyph_data = function()
     {
         var _index = argument[0];
@@ -1066,7 +1114,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__get_glyph_data(_index, _page);
     }
     
-    /// @param [page]
+	/// @param {Real.Int} page		Page to get the glyph count from. If not specified, the current page is used
+    /// @return {Real.Int}
     static get_glyph_count = function()
     {
         var _page = ((argument_count > 0) && (argument[0] != undefined))? argument[0] : __page;
@@ -1076,7 +1125,7 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__get_glyph_count(_page);
     }
     
-    /// @param [page]
+    /// @return {Real.Int}
     static get_line_count = function()
     {
         var _page = ((argument_count > 0) && (argument[0] != undefined))? argument[0] : __page;
@@ -1092,6 +1141,8 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Typewriter
     
+	/// @param {Id.Scribble.typist} typist		Typist being used to render the text element. See scribble_typist() for more information
+	/// @returns {Id.Scribble.element}
     static pre_update_typist = function(_typist)
     {
         var _function_scope = other;
@@ -1108,6 +1159,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real.Int} character		The number of characters to reveal
+	/// @returns {Id.Scribble.element}
     static reveal = function(_character)
     {
         if (__tw_reveal != _character)
@@ -1119,6 +1172,7 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @returns {Real.Int}
     static get_reveal = function()
     {
         return __tw_reveal;
@@ -1130,11 +1184,14 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Animation
     
+	/// @desc	.animation_tick_speed() has been replaced by .animation_speed()
     static animation_tick_speed = function()
     {
         __scribble_error(".animation_tick_speed() has been replaced by .animation_speed()");
     }
     
+	/// @returns {Real} speed		The animation speed multiplier where 1 is normal speed, 2 is double speed, and 0.5 is half speed
+    /// @returns {Id.Scribble.element}
     static animation_speed = function(_speed)
     {
         __animation_speed = _speed;
@@ -1142,11 +1199,13 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @returns {Real.Int}
     static get_animation_speed = function()
     {
         return __animation_speed;
     }
     
+	/// @returns {Bool}
     static is_animated = function()
     {
         var _model = __get_model(true);
@@ -1155,51 +1214,61 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _model.__has_animation;
     }
     
+	/// @desc	.animation_sync() has been removed\nPlease get in touch if this feature is essential for your project
     static animation_sync = function()
     {
         __scribble_error(".animation_sync() has been removed\nPlease get in touch if this feature is essential for your project");
     }
     
+	/// @desc	.animation_wave() has been replaced by scribble_anim_wave()
     static animation_wave = function()
     {
         __scribble_error(".animation_wave() has been replaced by scribble_anim_wave()");
     }
     
+	/// @desc	.animation_wave() has been replaced by scribble_anim_shake()
     static animation_shake = function()
     {
         __scribble_error(".animation_wave() has been replaced by scribble_anim_shake()");
     }
     
+	/// @desc	.animation_rainbow() has been replaced by scribble_anim_rainbow()
     static animation_rainbow = function()
     {
         __scribble_error(".animation_rainbow() has been replaced by scribble_anim_rainbow()");
     }
     
+	/// @desc	.animation_wobble() has been replaced by scribble_anim_wobble()
     static animation_wobble = function()
     {
         __scribble_error(".animation_wobble() has been replaced by scribble_anim_wobble()");
     }
     
+	/// @desc	.animation_pulse() has been replaced by scribble_anim_pulse()
     static animation_pulse = function()
     {
         __scribble_error(".animation_pulse() has been replaced by scribble_anim_pulse()");
     }
     
+	/// @desc	.animation_wheel() has been replaced by scribble_anim_wheel()
     static animation_wheel = function()
     {
         __scribble_error(".animation_wheel() has been replaced by scribble_anim_wheel()");
     }
     
+	/// @desc	.animation_cycle() has been replaced by scribble_anim_cycle()
     static animation_cycle = function()
     {
         __scribble_error(".animation_cycle() has been replaced by scribble_anim_cycle()");
     }
     
+	/// @desc	.animation_jitter() has been replaced by scribble_anim_jitter()
     static animation_jitter = function()
     {
         __scribble_error(".animation_jitter() has been replaced by scribble_anim_jitter()");
     }
     
+	/// @desc	.animation_blink() has been replaced by scribble_anim_blink()
     static animation_blink = function()
     {
         __scribble_error(".animation_blink() has been replaced by scribble_anim_blink()");
@@ -1211,6 +1280,9 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Outline & Shadow
     
+	/// @param {Real.Int|Constant.Colour}	colour	The colour of the shadow, as a standard GameMaker 24-bit BGR format
+	/// @param {Real}		alpha	Opacity of the shadow, 0.0 being transparent and 1.0 being fully opaque
+	/// @returns {Id.Scribble.element}
     static shadow = function(_colour, _alpha)
     {
         __sdf_shadow_colour   = _colour;
@@ -1222,6 +1294,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real.Int}	colour	Colour of the glyph’s outline, as a standard GameMaker 24-bit BGR format
+	/// @returns {Id.Scribble.element}
     static outline = function(_colour)
     {
         __sdf_outline_colour    = _colour;
@@ -1236,6 +1310,12 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region SDF
     
+	/// @param {Real.Int|Constant.Colour}	colour		The colour of the shadow, as a standard GameMaker 24-bit BGR format
+	/// @param {Real}						alpha		Opacity of the shadow, 0.0 being transparent and 1.0 being fully opaque
+	/// @param {Real}						xoffset		x-coordinate of the shadow, relative to the parent glyph
+	/// @param {Real}						yoffset		y-coordinate of the shadow, relative to the parent glyph
+	/// @param {Real}						softness	Optional. Larger values give a softer edge to the shadow. If not specified, this will default to 0.1 (which draws an antialiased but clean shadow edge)
+	/// @returns {Id.Scribble.element}
     static sdf_shadow = function(_colour, _alpha, _x_offset, _y_offset, _softness = 0.25)
     {
         __sdf_shadow_colour   = _colour;
@@ -1248,6 +1328,8 @@ function __scribble_class_element(_string, _unique_id) constructor
     }
     
     //TODO - DEPRECATED, remove in v10
+	/// @desc	DEPRECATED, planned for removal in v10
+	/// @returns {Id.Scribble.element}
     static sdf_border = function(_colour, _thickness)
     {
         __sdf_outline_colour    = _colour;
@@ -1256,6 +1338,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real.Int|Constant.Colour}	colour		The colour of the outline, as a standard GameMaker 24-bit BGR format
+	/// @param {Real}						thickness	Thickness of the outline, in pixels
+	/// @returns {Id.Scribble.element}
     static sdf_outline = function(_colour, _thickness)
     {
         __sdf_outline_colour    = _colour;
@@ -1264,18 +1349,23 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @returns {Id.Scribble.element}
     static msdf_shadow = function(_colour, _alpha, _x_offset, _y_offset, _softness = 0.25)
     {
         __scribble_error(".msdf_shadow(), and MSDF fonts as a whole, have been removed from Scribble\nInstead, please use GameMaker's native SDF fonts");
         return self;
     }
     
+	/// @desc	.msdf_border(), and MSDF fonts as a whole, have been removed from Scribble\nInstead, please use GameMaker's native SDF fonts
+	/// @returns {Id.Scribble.element}
     static msdf_border = function(_colour, _thickness)
     {
         __scribble_error(".msdf_border(), and MSDF fonts as a whole, have been removed from Scribble\nInstead, please use GameMaker's native SDF fonts");
         return self;
     }
     
+	/// @desc	.msdf_feather(), and MSDF fonts as a whole, have been removed from Scribble\nInstead, please use GameMaker's native SDF fonts
+	/// @returns {Id.Scribble.element}
     static msdf_feather = function(_thickness)
     {
         __scribble_error(".msdf_feather(), and MSDF fonts as a whole, have been removed from Scribble\nInstead, please use GameMaker's native SDF fonts");
@@ -1288,7 +1378,8 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Cache Management
     
-     /// @param freeze
+    /// @param {Bool} freeze	Whether to freeze generated vertex buffers
+	/// @returns {Id.Scribble.element}
     static build = function(_freeze)
     {
         __freeze = _freeze;
@@ -1306,6 +1397,7 @@ function __scribble_class_element(_string, _unique_id) constructor
         }
     }
     
+	/// @returns {Id.Scribble.element}
     static refresh = function()
     {
         var _model = __get_model(false);
@@ -1358,6 +1450,8 @@ function __scribble_class_element(_string, _unique_id) constructor
     
     #region Miscellaneous
     
+	/// @param {Function|Script} function	he function to execute as a preprocessor. Set to undefined to use the global default preprocessor, or set to SCRIBBLE_NO_PREPROCESS to force no preprocessing
+	/// @returns {Id.Scribble.element}
     static preprocessor = function(_function)
     {
         if (_function != __preprocessorFunc)
@@ -1374,6 +1468,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real.Int} position	Character to get events for. See below for more details
+	/// @param {Real.Int} [page]	The page to get events for. If not specified, the current page will be used
+    /// @returns {Array<Struct>}
     static get_events = function(_position, _page_index = __page, _use_lines = false)
     {
         static _empty_array = [];
@@ -1390,8 +1487,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return _events;
     }
     
-    /// @param templateFunction/Array
-    /// @param [executeOnlyOnChange=true]
+    /// @param {Function|Array<Function>} function	Function to execute to set Scribble behaviour for this text element
+    /// @param {Bool} [executeOnlyOnChange=true]	Whether to only execute the template function if it has changed. Defaults to true
+	/// @returns {Id.Scribble.element}
     static template = function(_template, _on_change = true)
     {
         if (is_array(_template))
@@ -1429,7 +1527,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
-    /// @param state
+    /// @param {Bool} state		Whether to ignore command tags
+	/// @returns {Id.Scribble.element}
     static ignore_command_tags = function(_state)
     {
         if (__ignore_command_tags != _state)
@@ -1441,6 +1540,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Bool} state		Whether to randomize the order that glyphs are animated
+	/// @returns {Id.Scribble.element}
     static randomize_animation = function(_state)
     {
         if (__randomize_animation != _state)
@@ -1452,6 +1553,8 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real} z		The z coordinate to draw the text element at
+	/// @returns {Id.Scribble.element}
     static z = function(_z)
     {
         __z = _z;
@@ -1459,13 +1562,15 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @returns {Real}
     static get_z = function()
     {
         return __z;
     }
     
-    /// @param string
-    /// @param [uniqueID]
+    /// @param {String} string		New string to display using the text element
+    /// @param {String} [uniqueID]	
+	/// @returns {Id.Scribble.element}
     static overwrite = function(_text, _unique_id = __unique_id)
     {
         __text      = _text;
@@ -1496,6 +1601,9 @@ function __scribble_class_element(_string, _unique_id) constructor
         return self;
     }
     
+	/// @param {Real} x
+	/// @param {Real} y
+	/// @returns {Id.Scribble.element}
     static debug_draw_bbox = function(_x, _y)
     {
         //FIXME - Reimplement properly

--- a/scripts/__scribble_class_font/__scribble_class_font.gml
+++ b/scripts/__scribble_class_font/__scribble_class_font.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param fontName
-/// @param glyphCount
-/// @param fontType
+/// @param {String} fontName
+/// @param {Real} glyphCount
+/// @param {Constant.__SCRIBBLE_FONT_TYPE} fontType
 
 function __scribble_class_font(_name, _glyph_count, _fontType) constructor
 {

--- a/scripts/__scribble_class_model/__scribble_class_model.gml
+++ b/scripts/__scribble_class_model/__scribble_class_model.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param element
-/// @param modelCacheName
+/// @param {Asset.Scribble.element} element
+/// @param {String} modelCacheName
 
 function __scribble_class_model(_element, _model_cache_name) constructor
 {
@@ -203,13 +203,13 @@ function __scribble_class_model(_element, _model_cache_name) constructor
         };
     }
     
-    /// @page
+    /// @param page
     static __get_width = function(_page)
     {
         return __fit_scale*__width;
     }
     
-    /// @page
+    /// @param page
     static __get_height = function(_page)
     {
         return __fit_scale*__height;

--- a/scripts/__scribble_class_null_element/__scribble_class_null_element.gml
+++ b/scripts/__scribble_class_null_element/__scribble_class_null_element.gml
@@ -362,7 +362,6 @@ function __scribble_class_null_element() constructor
     
     #region Cache Management
     
-     /// @param freeze
     static build = function()
     {
         __error();
@@ -391,7 +390,7 @@ function __scribble_class_null_element() constructor
         __error();
     }
     
-    /// @param state
+    /// @param {Real.Int} state
     static ignore_command_tags = function()
     {
         __error();
@@ -407,8 +406,8 @@ function __scribble_class_null_element() constructor
         __error();
     }
     
-    /// @param string
-    /// @param [uniqueID]
+    /// @param {String} string
+    /// @param {String} [uniqueID]
     static overwrite = function()
     {
         __error();

--- a/scripts/__scribble_class_typist/__scribble_class_typist.gml
+++ b/scripts/__scribble_class_typist/__scribble_class_typist.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param perLine
+/// @param {Bool} perLine
 
 function __scribble_class_typist(_per_line) constructor
 {
@@ -58,6 +58,7 @@ function __scribble_class_typist(_per_line) constructor
     
     #region Setters
     
+	/// @returns {Id.Scribble.typist}
     static reset = function()
     {
         __last_page            = 0;
@@ -79,8 +80,9 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
-    /// @param speed
-    /// @param smoothness
+    /// @param {Real} speed			Amount of text to reveal per tick (1 tick is usually 1 frame). This is character or lines depending on the method defined above
+    /// @param {Real} smoothness	How much text is visible during the fade. Higher numbers will allow more text to be visible as it fades in
+	/// @returns {Id.Scribble.typist}
     static in = function(_speed, _smoothness)
     {
         var _old_in = __in;
@@ -96,9 +98,10 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
-    /// @param speed
-    /// @param smoothness
-    /// @param [backwards=false]
+    /// @param {Real} speed				Amount of text to reveal per tick (1 tick is usually 1 frame). This is character or lines depending on the method defined above
+    /// @param {Real} smoothness		How much text is visible during the fade. Higher numbers will allow more text to be visible as it fades out
+    /// @param {Bool} [backwards=false]	Whether to animate the typewriter backwards. Defaults to false
+	/// @returns {Id.Scribble.typist}
     static out = function(_speed, _smoothness, _backwards = false)
     {
         var _old_in = __in;
@@ -114,6 +117,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @param {Bool} state	Whether the typist should skip the typewriter animation
+	/// @returns {Id.Scribble.typist}
     static skip = function(_state = true)
     {
         __skip = _state;
@@ -124,6 +129,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @param {Bool} state	Whether the typist should skip the typewriter animation
+	/// @returns {Id.Scribble.typist}
     static skip_to_pause = function(_state = true)
     {
         __skip = _state;
@@ -134,6 +141,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+    /// @param {Bool} state	Whether the typist should skip the typewriter animation
+	/// @returns {Id.Scribble.typist}
     static ignore_delay = function(_state = true)
     {
         __ignore_delay = _state;
@@ -141,11 +150,12 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
-    /// @param soundArray
-    /// @param overlap
-    /// @param pitchMin
-    /// @param pitchMax
-    /// @param [gain=1]
+    /// @param {Array<Asset.GMSound>} soundArray	Array of audio assets that can be used for playback
+    /// @param {Real} overlap						Amount of overlap between sound effect playback, in milliseconds
+    /// @param {Real.Float} pitchMin				Minimum pitch to play a sound at. A value of 1.0 gives no change in pitch, a value of 0.5 halves the pitch etc.
+    /// @param {Real.Float} pitchMax				Maximum pitch to play a sound at. A value of 1.0 gives no change in pitch, a value of 2.0 doubles the pitch etc.
+    /// @param {Real.Float} [gain=1]				Gain to play the sound at, from 0.0 (silence) to 1.0 (full volume). Defaults to 1
+	/// @returns {Id.Scribble.typist}
     static sound = function(_in_sound_array, _overlap, _pitch_min, _pitch_max, _gain = 1)
     {
         var _sound_array = _in_sound_array;
@@ -161,11 +171,12 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
-    /// @param soundArray
-    /// @param pitchMin
-    /// @param pitchMax
-    /// @param [exceptionString]
-    /// @param [gain=1]
+    /// @param {Array<Asset.GMSound>} soundArray	Array of audio assets that can be used for playback
+    /// @param {Real.Float} pitchMin				Minimum pitch to play a sound at. A value of 1.0 gives no change in pitch, a value of 0.5 halves the pitch etc.
+    /// @param {Real.Float} pitchMax				Maximum pitch to play a sound at. A value of 1.0 gives no change in pitch, a value of 2.0 doubles the pitch etc.
+    /// @param {String} [exceptionString]			String of characters for whom a sound should not be played. If no string is specified, all characters will play a sound when revealed
+    /// @param {Real.Float} [gain=1]				Gain to play the sound at, from 0.0 (silence) to 1.0 (full volume). Defaults to 1
+	/// @returns {Id.Scribble.typist}
     static sound_per_char = function(_in_sound_array, _pitch_min, _pitch_max, _exception_string, _gain = 1)
     {
         var _sound_array = _in_sound_array;
@@ -199,6 +210,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+    /// @param {Function} function	Function to execute when a new character is revealed
+	/// @returns {Id.Scribble.typist}
     static function_per_char = function(_function)
     {
         __function_per_char = _function;
@@ -206,6 +219,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+    /// @param {Function} function	Function to execute when a typist finishes animating
+	/// @returns {Id.Scribble.typist}
     static function_on_complete = function(_function)
     {
         __function_on_complete = _function;
@@ -213,6 +228,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+    /// @param {Id.Instance|Struct} scope	The new scope to execution typist functions in
+	/// @returns {Id.Scribble.typist}
     static execution_scope = function(_scope)
     {
         __function_scope = _scope;
@@ -220,6 +237,7 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @returns {Id.Scribble.typist}
     static pause = function()
     {
         __paused = true;
@@ -227,6 +245,7 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @returns {Id.Scribble.typist}
     static unpause = function()
     {
         if (__paused)
@@ -244,13 +263,14 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
-    /// @param easeMethod
-    /// @param dx
-    /// @param dy
-    /// @param xscale
-    /// @param yscale
-    /// @param rotation
-    /// @param alphaDuration
+    /// @param {Constant.SCRIBBLE_EASE} easeMethod		A member of the SCRIBBLE_EASE enum. See below
+    /// @param {Real} dx								Starting x-coordinate of the glyph, relative to its final position
+    /// @param {Real} dy								Starting y-coordinate of the glyph, relative to its final position
+    /// @param {Real} xscale							Starting x-scale of the glyph, relative to its final scale
+    /// @param {Real} yscale							Starting y-scale of the glyph, relative to its final scale
+    /// @param {Real} rotation							Starting rotation of the glyph, relative to its final rotation
+    /// @param {Real.Float} alphaDuration				Value from 0 to 1 (inclusive). See below
+	/// @returns {Id.Scribble.typist}
     static ease = function(_ease_method, _dx, _dy, _xscale, _yscale, _rotation, _alpha_duration)
     {
         __ease_method         = _ease_method;
@@ -264,6 +284,10 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @param {String} character	A single character or a pair of characters, the substring to search for to apply a delay during typist animation
+    /// @param {Number} delay		The length of time to delay for, in milliseconds
+    /// @param {Real.Float} alphaDuration				Value from 0 to 1 (inclusive).
+	/// @returns {Id.Scribble.typist}
     static character_delay_add = function(_character, _delay)
     {
         if (!SCRIBBLE_ALLOW_GLYPH_DATA_GETTER) __scribble_error("SCRIBBLE_ALLOW_GLYPH_DATA_GETTER must be set to <true> to use per-character delay");
@@ -284,6 +308,8 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @param {string} character	A single character or a pair of characters, the substring whose delay should be removed from the typist
+	/// @returns {Id.Scribble.typist}
     static character_delay_remove = function(_character)
     {
         var _char_1 = _character;
@@ -301,6 +327,7 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @returns {Id.Scribble.typist}
     static character_delay_clear = function()
     {
         __character_delay = false;
@@ -315,16 +342,19 @@ function __scribble_class_typist(_per_line) constructor
     
     #region Getters
     
+	/// @returns {Bool}
     static get_skip = function()
     {
         return __skip;
     }
     
+	/// @returns {Bool}
     static get_ignore_delay = function()
     {
         return __ignore_delay;
     }
     
+	/// @returns {Real}
     static get_state = function()
     {
         if ((__last_element == undefined) || (__last_page == undefined) || (__last_character == undefined)) return 0.0;
@@ -362,27 +392,32 @@ function __scribble_class_typist(_per_line) constructor
         }
     }
     
+	/// @returns {Bool}
     static get_delay_paused = function()
     {
         return __delay_paused;
     }
     
+	/// @returns {Bool}
     static get_paused = function()
     {
         return __paused;
     }
     
+	/// @returns {Real}
     static get_position = function()
     {
         if (__in == undefined) return 0;
         return __window_array[__window_index];
     }
     
+	/// @returns {Id.Scribble.element|undefined}
     static get_text_element = function()
     {
         return weak_ref_alive(__last_element)? __last_element.ref : undefined;
     }
     
+	/// @returns {Id.Instance|Struct|undefined}
     static get_execution_scope = function()
     {
         return __function_scope;
@@ -394,6 +429,8 @@ function __scribble_class_typist(_per_line) constructor
     
     #region Sync
     
+	/// @param {Id.Sound} soundInstance	Sound instance to use as the basis for synchronisation
+	/// @returns {Id.Scribble.typist}
     static sync_to_sound = function(_instance)
     {
         if (_instance < 400000)
@@ -416,6 +453,7 @@ function __scribble_class_typist(_per_line) constructor
         return self;
     }
     
+	/// @returns {undefined}
     static __sync_reset = function()
     {
         __sync_started   = false;
@@ -430,12 +468,15 @@ function __scribble_class_typist(_per_line) constructor
     
     #region Gain
     
+	/// @param {Real.Float} gain	Gain to play the sound tags at, from 0.0 (silence) to 1.0 (full volume)
+	/// @returns {Id.Scribble.typist}
     static set_sound_tag_gain = function(_gain)
     {
         __sound_tag_gain = _gain;
         return self;
     }
     
+	/// @returns {Real.Float}
     static get_sound_tag_gain = function()
     {
         return __sound_tag_gain;
@@ -447,6 +488,7 @@ function __scribble_class_typist(_per_line) constructor
     
     #region Private Methods
     
+	// ToDo: update these internal jsDocs
     static __associate = function(_text_element)
     {
         var _carry_skip = __skip && ((__last_element == undefined) || !__drawn_since_skip);

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param font
+/// @param {Asset.GMFont} font
 
 function __scribble_font_add_from_project(_font)
 {

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = font_get_texture(_asset);
+        var _texture     = font_get_info(_asset).texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID -Red (2025/03/23)
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = __scribble_font_get_texture_id(_asset);
+        var _texture     = __scribble_font_get_texture(_asset);
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
+++ b/scripts/__scribble_font_add_from_project/__scribble_font_add_from_project.gml
@@ -47,7 +47,7 @@ function __scribble_font_add_from_project(_font)
         if (SCRIBBLE_VERBOSE) __scribble_trace("Processing font \"" + _name + "\"");
         
         var _asset       = asset_get_index(_name);
-        var _texture     = font_get_info(_asset).texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID -Red (2025/03/23)
+        var _texture     = __scribble_font_get_texture_id(_asset);
         var _texture_uvs = font_get_uvs(_asset);
         
         var _texture_tw = texture_get_texel_width(_texture);

--- a/scripts/__scribble_font_add_sprite/__scribble_font_add_sprite.gml
+++ b/scripts/__scribble_font_add_sprite/__scribble_font_add_sprite.gml
@@ -129,16 +129,7 @@ function __scribble_font_add_sprite_common(_sprite, _spritefont, _proportional, 
         {
             var _image_info = _sprite_frames[_image];
             
-            //Convert the texture index to a texture pointer
-            var _texture_index = _image_info.texture;
-            
-            static _tex_index_lookup_map = ds_map_create();
-            var _texture = _tex_index_lookup_map[? _texture_index];
-            if (_texture == undefined)
-            {
-                _texture = sprite_get_texture(_sprite, _image);
-                _tex_index_lookup_map[? _texture_index] = _texture;
-            }
+            var _texture = __scribble_sprite_get_texture(_sprite, _image)
             
             if (_proportional)
             {

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = __scribble_sprite_get_texture_id(_sprite_index, _j);
+                    var _glyph_texture = __scribble_sprite_get_texture(_sprite_index, _j);
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = sprite_get_info(_sprite_index).frames[_j].texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID
+                    var _glyph_texture = __scribble_sprite_get_texture_id(_sprite_index, _j);
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
+++ b/scripts/__scribble_gen_9_write_vbuffs/__scribble_gen_9_write_vbuffs.gml
@@ -322,7 +322,7 @@ function __scribble_gen_9_write_vbuffs()
                 var _j = _image_index;
                 repeat((_image_speed > 0)? _sprite_number : 1) //Only draw one image if we have an image speed of 0 since we're not animating
                 {
-                    var _glyph_texture = sprite_get_texture(_sprite_index, _j);
+                    var _glyph_texture = sprite_get_info(_sprite_index).frames[_j].texture; // NOTE :: HTML5 does not support using the texture ID in place of the texture pointer, this is the texture ID
                     
                     var _uvs = sprite_get_uvs(_sprite_index, _j);
                     var _quad_u0 = _uvs[0];

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -362,7 +362,7 @@ function __scribble_matrix_inverse(_matrix)
 function __scribble_sprite_get_texture(_sprite_index, _image_index)
 {
 	static __texture_id_lookup = ds_map_create();
-	static __texture_pointer_lookup = ds_map_create();
+	static __texture_pointer_lookup = __scribble_texture_pointer_lookup();
 	
 	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index);
 	var _texture_id = __texture_id_lookup[? _key];
@@ -376,7 +376,7 @@ function __scribble_sprite_get_texture(_sprite_index, _image_index)
 	if (_pointer == undefined)
 	{
 		_pointer = sprite_get_texture(_sprite_index, _image_index);
-		__texture_pointer_lookup[? _key] = _texture_id;
+		__texture_pointer_lookup[? _texture_id] = _pointer;
 	}
 	
 	return _pointer;
@@ -385,7 +385,7 @@ function __scribble_sprite_get_texture(_sprite_index, _image_index)
 function __scribble_font_get_texture(_font)
 {
 	static __texture_id_lookup = ds_map_create();
-	static __texture_pointer_lookup = ds_map_create();
+	static __texture_pointer_lookup = __scribble_texture_pointer_lookup();
 	
 	var _key = font_get_name(_font);
 	var _texture_id = __texture_id_lookup[? _key];
@@ -399,11 +399,18 @@ function __scribble_font_get_texture(_font)
 	if (_pointer == undefined)
 	{
 		_pointer = font_get_texture(_font);
-		__texture_pointer_lookup[? _key] = _texture_id;
+		__texture_pointer_lookup[? _texture_id] = _pointer;
 	}
 	
 	return _pointer;
 }
+
+function __scribble_texture_pointer_lookup()
+{
+	static __texture_pointer_lookup = ds_map_create();
+	return __texture_pointer_lookup;
+}
+
 
 #region Enums
 

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -359,49 +359,50 @@ function __scribble_matrix_inverse(_matrix)
     return _inv;
 }
 
-function __scribble_sprite_get_texture_id(_sprite_index, _image_index)
+function __scribble_sprite_get_texture(_sprite_index, _image_index)
 {
-	static __cache = {}
+	static __texture_id_lookup = ds_map_create();
+	static __texture_pointer_lookup = ds_map_create();
 	
-	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index)
-	var _val = __cache[$ _key];
-	if (_val != undefined)
+	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index);
+	var _texture_id = __texture_id_lookup[? _key];
+	if (_texture_id == undefined)
 	{
-		return _val;
+		_texture_id = sprite_get_info(_sprite_index).frames[_image_index].texture;
+		__texture_id_lookup[? _key] = _texture_id;
 	}
 	
-	if (__SCRIBBLE_ON_WEB) {
-		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
-		_val = sprite_get_texture(_sprite_index, _image_index);
+	var _pointer = __texture_pointer_lookup[? _texture_id];
+	if (_pointer == undefined)
+	{
+		_pointer = sprite_get_texture(_sprite_index, _image_index);
+		__texture_pointer_lookup[? _key] = _texture_id;
 	}
-	else {
-		_val = sprite_get_info(_sprite_index).frames[_image_index].texture;
-	}
-	__cache[$ _key] = _val;
 	
-	return _val;
+	return _pointer;
 }
-function __scribble_font_get_texture_id(_font)
+
+function __scribble_font_get_texture(_font)
 {
-	static __cache = {}
+	static __texture_id_lookup = ds_map_create();
+	static __texture_pointer_lookup = ds_map_create();
 	
-	var _key = font_get_name(_font)
-	var _val = __cache[$ _key];
-	if (_val != undefined)
+	var _key = font_get_name(_font);
+	var _texture_id = __texture_id_lookup[? _key];
+	if (_texture_id == undefined)
 	{
-		return _val;
+		_texture_id = font_get_info(_font).texture;
+		__texture_id_lookup[? _key] = _texture_id;
 	}
 	
-	if (__SCRIBBLE_ON_WEB) {
-		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
-		_val = font_get_texture(_font);
+	var _pointer = __texture_pointer_lookup[? _texture_id];
+	if (_pointer == undefined)
+	{
+		_pointer = font_get_texture(_font);
+		__texture_pointer_lookup[? _key] = _texture_id;
 	}
-	else {
-		_val = font_get_info(_font).texture;
-	}
-	__cache[$ _key] = _val;
 	
-	return _val;
+	return _pointer;
 }
 
 #region Enums

--- a/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
+++ b/scripts/__scribble_misc_functions/__scribble_misc_functions.gml
@@ -359,6 +359,51 @@ function __scribble_matrix_inverse(_matrix)
     return _inv;
 }
 
+function __scribble_sprite_get_texture_id(_sprite_index, _image_index)
+{
+	static __cache = {}
+	
+	var _key = sprite_get_name(_sprite_index) + "_" + string(_image_index)
+	var _val = __cache[$ _key];
+	if (_val != undefined)
+	{
+		return _val;
+	}
+	
+	if (__SCRIBBLE_ON_WEB) {
+		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
+		_val = sprite_get_texture(_sprite_index, _image_index);
+	}
+	else {
+		_val = sprite_get_info(_sprite_index).frames[_image_index].texture;
+	}
+	__cache[$ _key] = _val;
+	
+	return _val;
+}
+function __scribble_font_get_texture_id(_font)
+{
+	static __cache = {}
+	
+	var _key = font_get_name(_font)
+	var _val = __cache[$ _key];
+	if (_val != undefined)
+	{
+		return _val;
+	}
+	
+	if (__SCRIBBLE_ON_WEB) {
+		// TODO: build look up table to fetch the best pointer so we can compare pointers better for batch breaks
+		_val = font_get_texture(_font);
+	}
+	else {
+		_val = font_get_info(_font).texture;
+	}
+	__cache[$ _key] = _val;
+	
+	return _val;
+}
+
 #region Enums
 
 enum __SCRIBBLE_GLYPH_LAYOUT

--- a/scripts/__scribble_play_sound/__scribble_play_sound.gml
+++ b/scripts/__scribble_play_sound/__scribble_play_sound.gml
@@ -1,8 +1,8 @@
 // Feather disable all
 
-/// @param sound
-/// @param gain
-/// @param pitch
+/// @param {Asset.GMSound} sound
+/// @param {Real} gain
+/// @param {Real} pitch
 
 function __scribble_play_sound(_sound, _gain, _pitch)
 {

--- a/scripts/draw_text_scribble/draw_text_scribble.gml
+++ b/scripts/draw_text_scribble/draw_text_scribble.gml
@@ -11,10 +11,10 @@
 /// 
 /// This will take full advantage of Scribble's power (and is less to type!)
 /// 
-/// @param x            The x coordinate of the drawn string
-/// @param y            The y coordinate of the drawn string
-/// @param string       The string to draw
-/// @param [charCount]  The number of characters from the string to draw. If not specified, all characters will be drawn
+/// @param {Real} x            The x coordinate of the drawn string
+/// @param {Real} y            The y coordinate of the drawn string
+/// @param {String} string       The string to draw
+/// @param {Real.Int} [charCount]  The number of characters from the string to draw. If not specified, all characters will be drawn
 
 function draw_text_scribble(_x, _y, _string, _reveal = undefined)
 {

--- a/scripts/draw_text_scribble_ext/draw_text_scribble_ext.gml
+++ b/scripts/draw_text_scribble_ext/draw_text_scribble_ext.gml
@@ -11,11 +11,11 @@
 /// 
 /// This will take full advantage of Scribble's power (and is less to type!)
 /// 
-/// @param x            The x coordinate of the drawn string
-/// @param y            The y coordinate of the drawn string
-/// @param string       The string to draw
-/// @param width        The maximum width in pixels of the string before a line break
-/// @param [charCount]  The number of characters from the string to draw. If not specified, all characters will be drawn
+/// @param {Real} x            The x coordinate of the drawn string
+/// @param {Real} y            The y coordinate of the drawn string
+/// @param {String} string       The string to draw
+/// @param {Real} width        The maximum width in pixels of the string before a line break
+/// @param {Real.Int} [charCount]  The number of characters from the string to draw. If not specified, all characters will be drawn
 
 function draw_text_scribble_ext(_x, _y, _string, _width, _reveal = undefined)
 {

--- a/scripts/example_dialogue_set_name/example_dialogue_set_name.gml
+++ b/scripts/example_dialogue_set_name/example_dialogue_set_name.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param   textElement
-/// @param   eventData{array}
-/// @param   characterIndex
+/// @param {Id.Scribble.element}   textElement
+/// @param {Array}   eventData{array}
+/// @param {Real.Int}   characterIndex
 
 function example_dialogue_set_name(_text_element, _event_data, _char_index)
 {

--- a/scripts/example_dialogue_set_portrait/example_dialogue_set_portrait.gml
+++ b/scripts/example_dialogue_set_portrait/example_dialogue_set_portrait.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param   textElement
-/// @param   eventData{array}
-/// @param   characterIndex
+/// @param {Id.Scribble.element}   textElement
+/// @param {Array}   eventData{array}
+/// @param {Real.Int}   characterIndex
 
 function example_dialogue_set_portrait(_text_element, _event_data, _char_index)
 {

--- a/scripts/scribble/scribble.gml
+++ b/scripts/scribble/scribble.gml
@@ -2,8 +2,8 @@
 /// Returns a Scribble text element corresponding to the input string
 /// If a text element with the same input string (and unique ID) has been cached, this function will return the cached text element
 /// 
-/// @param string       The string to parse and, eventually, draw
-/// @param [uniqueID]   A unique identifier that can be used to distinguish this occurrence of the input string from other occurrences. Only necessary when you might be drawing the same string at the same time with different animation states
+/// @param {String} string       The string to parse and, eventually, draw
+/// @param {String} [uniqueID]   A unique identifier that can be used to distinguish this occurrence of the input string from other occurrences. Only necessary when you might be drawing the same string at the same time with different animation states
 
 function scribble(_string, _unique_id = undefined)
 {

--- a/scripts/scribble_add_macro/scribble_add_macro.gml
+++ b/scripts/scribble_add_macro/scribble_add_macro.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param name
-/// @param function
+/// @param {String} name
+/// @param {Function} function
 
 function scribble_add_macro(_name, _function)
 {

--- a/scripts/scribble_anim_blink/scribble_anim_blink.gml
+++ b/scripts/scribble_anim_blink/scribble_anim_blink.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param onDuration   Duration that blinking text should stay on for, in milliseconds
-/// @param offDuration  Duration that blinking text should turn off for, in milliseconds
-/// @param timeOffset   Blink time offset, in milliseconds
+/// @param {Real} onDuration   Duration that blinking text should stay on for, in milliseconds
+/// @param {Real} offDuration  Duration that blinking text should turn off for, in milliseconds
+/// @param {Real} timeOffset   Blink time offset, in milliseconds
 
 function scribble_anim_blink(_on_duration, _off_duration, _time_offset)
 {

--- a/scripts/scribble_anim_cycle/scribble_anim_cycle.gml
+++ b/scripts/scribble_anim_cycle/scribble_anim_cycle.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param speed       Cycle speed. Larger numbers cause characters to change colour more rapidly
-/// @param saturation  Cycle colour saturation, from 0 to 255. Colour cycles using the HSV model to create colours
-/// @param value       Cycle colour value, from 0 to 255. Colour cycles using the HSV model to create colours
+/// @param {Real} speed       Cycle speed. Larger numbers cause characters to change colour more rapidly
+/// @param {Real.Int} saturation  Cycle colour saturation, from 0 to 255. Colour cycles using the HSV model to create colours
+/// @param {Real.Int} value       Cycle colour value, from 0 to 255. Colour cycles using the HSV model to create colours
 
 function scribble_anim_cycle(_speed, _saturation, _value)
 {

--- a/scripts/scribble_anim_disabled/scribble_anim_disabled.gml
+++ b/scripts/scribble_anim_disabled/scribble_anim_disabled.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param state
+/// @param {Real.Int} state
 
 function scribble_anim_disabled(_state)
 {

--- a/scripts/scribble_anim_jitter/scribble_anim_jitter.gml
+++ b/scripts/scribble_anim_jitter/scribble_anim_jitter.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param minScale  Jitter minimum scale. Unlike SCRIBBLE_DEFAULT_PULSE_SCALE this is not an offset
-/// @param maxScale  Jitter maximum scale. Unlike SCRIBBLE_DEFAULT_PULSE_SCALE this is not an offset
-/// @param speed     Jitter speed. Larger values cause glyph scales to fluctuate faster
+/// @param {Real} minScale  Jitter minimum scale. Unlike SCRIBBLE_DEFAULT_PULSE_SCALE this is not an offset
+/// @param {Real} maxScale  Jitter maximum scale. Unlike SCRIBBLE_DEFAULT_PULSE_SCALE this is not an offset
+/// @param {Real} speed     Jitter speed. Larger values cause glyph scales to fluctuate faster
 
 function scribble_anim_jitter(_min_scale, _max_scale, _speed)
 {

--- a/scripts/scribble_anim_pulse/scribble_anim_pulse.gml
+++ b/scripts/scribble_anim_pulse/scribble_anim_pulse.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param scale  pulse scale offset. A value of 0 will cause no visible scaling changes for a glyph, a value of 1 will cause a glyph to double in size
-/// @param speed  pulse speed. Larger values cause glyph scales to pulse faster
+/// @param {Real} scale  pulse scale offset. A value of 0 will cause no visible scaling changes for a glyph, a value of 1 will cause a glyph to double in size
+/// @param {Real} speed  pulse speed. Larger values cause glyph scales to pulse faster
 
 function scribble_anim_pulse(_scale, _speed)
 {

--- a/scripts/scribble_anim_rainbow/scribble_anim_rainbow.gml
+++ b/scripts/scribble_anim_rainbow/scribble_anim_rainbow.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param weight  Rainbow blend weight. 0 does not show any rainbow effect at all, and 1 will blend a glyph's colour fully with the rainbow colour
-/// @param speed   Rainbow speed. Larger values cause characters to change colour more rapidly
+/// @param {Real} weight  Rainbow blend weight. 0 does not show any rainbow effect at all, and 1 will blend a glyph's colour fully with the rainbow colour
+/// @param {Real} speed   Rainbow speed. Larger values cause characters to change colour more rapidly
 
 function scribble_anim_rainbow(_weight, _speed)
 {

--- a/scripts/scribble_anim_shake/scribble_anim_shake.gml
+++ b/scripts/scribble_anim_shake/scribble_anim_shake.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param size   Shake amplitude, in pixels
-/// @param speed  Shake speed. Larger values cause characters to move around more rapidly
+/// @param {Real} size   Shake amplitude, in pixels
+/// @param {Real} speed  Shake speed. Larger values cause characters to move around more rapidly
 
 function scribble_anim_shake(_size, _speed)
 {

--- a/scripts/scribble_anim_wave/scribble_anim_wave.gml
+++ b/scripts/scribble_anim_wave/scribble_anim_wave.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param size       Wave amplitude, in pixels
-/// @param frequency  Wave frequency. Larger values create more "humps" over a certain number of characters
-/// @param speed      Wave speed. Larger numbers cause characters to move up and down more rapidly
+/// @param {Real} size       Wave amplitude, in pixels
+/// @param {Real} frequency  Wave frequency. Larger values create more "humps" over a certain number of characters
+/// @param {Real} speed      Wave speed. Larger numbers cause characters to move up and down more rapidly
 
 function scribble_anim_wave(_size, _frequency, _speed)
 {

--- a/scripts/scribble_anim_wheel/scribble_anim_wheel.gml
+++ b/scripts/scribble_anim_wheel/scribble_anim_wheel.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param size       Wheel amplitude, in pixels
-/// @param frequency  Wheel frequency. Larger values create more "humps" over a certain number of characters
-/// @param speed      Wheel speed. Larger numbers cause characters to move up and down more rapidly
+/// @param {Real} size       Wheel amplitude, in pixels
+/// @param {Real} frequency  Wheel frequency. Larger values create more "humps" over a certain number of characters
+/// @param {Real} speed      Wheel speed. Larger numbers cause characters to move up and down more rapidly
 
 function scribble_anim_wheel(_size, _frequency, _speed)
 {

--- a/scripts/scribble_anim_wobble/scribble_anim_wobble.gml
+++ b/scripts/scribble_anim_wobble/scribble_anim_wobble.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param angle      Maximum wobble angle. Larger values cause glyphs to oscillate further to the left and right
-/// @param frequency  Wobble frequency. Larger values cause glyphs to oscillate faster
+/// @param {Real} angle      Maximum wobble angle. Larger values cause glyphs to oscillate further to the left and right
+/// @param {Real} frequency  Wobble frequency. Larger values cause glyphs to oscillate faster
 
 function scribble_anim_wobble(_angle, _frequency)
 {

--- a/scripts/scribble_color_get/scribble_color_get.gml
+++ b/scripts/scribble_color_get/scribble_color_get.gml
@@ -2,7 +2,7 @@
 /// Returns the colour for the given colour name
 /// If the colour doesn't exist, this function will return <undefined>
 /// 
-/// @param name
+/// @param {String} name
 
 function scribble_color_get(_name)
 {

--- a/scripts/scribble_color_set/scribble_color_set.gml
+++ b/scripts/scribble_color_set/scribble_color_set.gml
@@ -11,8 +11,8 @@
 ///      colours frequently, and this function should typically be used at the start of the game or
 ///      on loading screens etc.
 /// 
-/// @param name
-/// @param colour
+/// @param {String} name
+/// @param {Real.Int|Constant.ColourColor} colour
 
 function scribble_color_set(_name, _colour)
 {

--- a/scripts/scribble_default_preprocessor_set/scribble_default_preprocessor_set.gml
+++ b/scripts/scribble_default_preprocessor_set/scribble_default_preprocessor_set.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param function
+/// @param {Function} function
 
 function scribble_default_preprocessor_set(_function)
 {

--- a/scripts/scribble_external_sound_add/scribble_external_sound_add.gml
+++ b/scripts/scribble_external_sound_add/scribble_external_sound_add.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param soundID
-/// @param alias
+/// @param {Asset.GMSound} soundID
+/// @param {String} alias
 
 function scribble_external_sound_add(_soundID, _alias)
 {

--- a/scripts/scribble_font_bake_outline_4dir/scribble_font_bake_outline_4dir.gml
+++ b/scripts/scribble_font_bake_outline_4dir/scribble_font_bake_outline_4dir.gml
@@ -1,11 +1,11 @@
 // Feather disable all
 /// Creates a new font with an outline based on a given source font
 ///
-/// @param sourceFontName   Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName      Name of the new font to create, as a string
-/// @param outlineColour    Colour of the outline
-/// @param smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
-/// @param [textureSize]
+/// @param {String}                        sourceFontName   Name, as a string, of the font to use as a basis for the effect
+/// @param {String}                        newFontName      Name of the new font to create, as a string
+/// @param {Real.Int|Constant.ColourColor} outlineColour    Colour of the outline
+/// @param {Bool}                          smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
+/// @param {Real.Int}                      [textureSize]
 
 function scribble_font_bake_outline_4dir(_source_font_name, _new_font_name, _outline_color, _smooth, _textureSize = undefined)
 {

--- a/scripts/scribble_font_bake_outline_8dir/scribble_font_bake_outline_8dir.gml
+++ b/scripts/scribble_font_bake_outline_8dir/scribble_font_bake_outline_8dir.gml
@@ -1,11 +1,11 @@
 // Feather disable all
 /// Creates a new font with an outline based on a given source font
 ///
-/// @param sourceFontName   Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName      Name of the new font to create, as a string
-/// @param outlineColour    Colour of the outline
-/// @param smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
-/// @param [textureSize]
+/// @param {String}                        sourceFontName   Name, as a string, of the font to use as a basis for the effect
+/// @param {String}                        newFontName      Name of the new font to create, as a string
+/// @param {Real.Int|Constant.ColourColor} outlineColour    Colour of the outline
+/// @param {Bool}                          smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
+/// @param {Real.Int}                      [textureSize]
 
 function scribble_font_bake_outline_8dir(_source_font_name, _new_font_name, _outline_color, _smooth, _textureSize = undefined)
 {

--- a/scripts/scribble_font_bake_outline_8dir_2px/scribble_font_bake_outline_8dir_2px.gml
+++ b/scripts/scribble_font_bake_outline_8dir_2px/scribble_font_bake_outline_8dir_2px.gml
@@ -1,11 +1,11 @@
 // Feather disable all
 /// Creates a new font with an outline based on a given source font
 ///
-/// @param sourceFontName   Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName      Name of the new font to create, as a string
-/// @param outlineColour    Colour of the outline
-/// @param smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
-/// @param [textureSize]
+/// @param {String}                        sourceFontName   Name, as a string, of the font to use as a basis for the effect
+/// @param {String}                        newFontName      Name of the new font to create, as a string
+/// @param {Real.Int|Constant.ColourColor} outlineColour    Colour of the outline
+/// @param {Bool}                          smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
+/// @param {Real.Int}                      [textureSize]
 
 function scribble_font_bake_outline_8dir_2px(_source_font_name, _new_font_name, _outline_color, _smooth, _textureSize = undefined)
 {

--- a/scripts/scribble_font_bake_outline_and_shadow/scribble_font_bake_outline_and_shadow.gml
+++ b/scripts/scribble_font_bake_outline_and_shadow/scribble_font_bake_outline_and_shadow.gml
@@ -4,14 +4,14 @@
 /// pack shadow and outline information into the green and blue channels whereas the "core" glyph
 /// will occupy the red channel.
 ///
-/// @param sourceFontName   Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName      Name of the new font to create, as a string
-/// @param shadowX          
-/// @param shadowY          
-/// @param outlineMode      Type of outline, member of SCRIBBLE_OUTLINE
-/// @param separation       Additional separation to add between glyphs
-/// @param smooth           Whether or not to interpolate the effect. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
-/// @param [textureSize]
+/// @param {String}                    sourceFontName   Name, as a string, of the font to use as a basis for the effect
+/// @param {String}                    newFontName      Name of the new font to create, as a string
+/// @param {Real}                      shadowX          x-axis displacement for the shadow
+/// @param {Real}                      shadowY          y-axis displacement for the shadow
+/// @param {Constant.SCRIBBLE_OUTLINE} outlineMode      Type of outline, member of SCRIBBLE_OUTLINE
+/// @param {Real}                      separation       Additional separation to add between glyphs
+/// @param {Bool}                      smooth           Whether or not to interpolate the effect. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
+/// @param {Real.Int}                  [textureSize]
 
 function scribble_font_bake_outline_and_shadow(_sourceFontName, _newFontName, _dX, _dY, _outlineMode, _separation, _smooth, _textureSize = undefined)
 {

--- a/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
+++ b/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
@@ -90,12 +90,14 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
         
         //Ignore any glyphs with invalid textures
         //Due to HTML5 being dogshit, we can't use is_ptr()
-        if (is_numeric(_texture) || is_undefined(_texture))
-        {
+		// Expect numeric texture ID for non html platforms
+		if (is_undefined(_texture))
+        || (__SCRIBBLE_ON_WEB && is_numeric(_texture))
+		{
             ++_i;
             continue;
         }
-        
+		
         var _width_ext  = _width  + _outline + _l_pad + _r_pad;
         var _height_ext = _height + _outline + _t_pad + _b_pad;
         
@@ -223,8 +225,6 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     _new_font_data.__source_sprite = _sprite;
     surface_free(_surface_1);
     
-    
-    
     //Make bulk corrections to various glyph properties based on the input parameters
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.X_OFFSET,    _glyph_count-1, SCRIBBLE_GLYPH.X_OFFSET,    -_l_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.Y_OFFSET,    _glyph_count-1, SCRIBBLE_GLYPH.Y_OFFSET,    -_t_pad);
@@ -232,7 +232,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.HEIGHT,      _glyph_count-1, SCRIBBLE_GLYPH.HEIGHT,      _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_HEIGHT, _glyph_count-1, SCRIBBLE_GLYPH.FONT_HEIGHT, _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.SEPARATION,  _glyph_count-1, SCRIBBLE_GLYPH.SEPARATION,  _separation);
-    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     sprite_get_texture(_sprite, 0));
+    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture_id(_sprite, 0));
     ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_NAME,   _glyph_count-1, SCRIBBLE_GLYPH.FONT_NAME,   _new_font_name);
     
     //Figure out the new UVs using some bulk commands

--- a/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
+++ b/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
@@ -1,18 +1,18 @@
 // Feather disable all
 /// Creates a new font with an outline based on a given source font
 ///
-/// @param sourceFontName              Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName                 Name of the new font to create, as a string
-/// @param shader                      Shader to use
-/// @param emptyOutlineSize            Outline around the outside of every output glyph, in pixels. A value of 2 is typical
-/// @param leftPad                     Padding around the outside of every *input* glyph. Positive values give more space. e.g. For a shader that adds a outline of 2px around the entire glyph, *all* padding arguments should be set to <2>
-/// @param topPad                      "
-/// @param rightPad                    "
-/// @param bottomPad                   "
-/// @param separationDelta             Change in every glyph's SCRIBBLE_GLYPH.SEPARATION value. For a shader that adds a outline of 2px around the entire glyph, this value should be 4px
-/// @param smooth                      Set to <true> to turn on linear interpolation
-/// @param [surfaceSize=2048]          Size of the surface to use. Defaults to 2048x2048
-/// @param [markAsRasterEffect=false]
+/// @param {string} sourceFontName              Name, as a string, of the font to use as a basis for the effect
+/// @param {string} newFontName                 Name of the new font to create, as a string
+/// @param {Asset.GMShader} shader                      Shader to use
+/// @param {Real} emptyOutlineSize            Outline around the outside of every output glyph, in pixels. A value of 2 is typical
+/// @param {Real} leftPad                     Padding around the outside of every *input* glyph. Positive values give more space. e.g. For a shader that adds a outline of 2px around the entire glyph, *all* padding arguments should be set to <2>
+/// @param {Real} topPad                      "
+/// @param {Real} rightPad                    "
+/// @param {Real} bottomPad                   "
+/// @param {Real} separationDelta             Change in every glyph's SCRIBBLE_GLYPH.SEPARATION value. For a shader that adds a outline of 2px around the entire glyph, this value should be 4px
+/// @param {Bool} smooth                      Set to <true> to turn on linear interpolation
+/// @param {Real} [surfaceSize=2048]          Size of the surface to use. Defaults to 2048x2048
+/// @param {Bool} [markAsRasterEffect=false]
 
 function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _outline, _l_pad, _t_pad, _r_pad, _b_pad, _separation, _smooth, _texture_size = 2048, _markAsRasterEffect = false)
 {

--- a/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
+++ b/scripts/scribble_font_bake_shader/scribble_font_bake_shader.gml
@@ -90,9 +90,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
         
         //Ignore any glyphs with invalid textures
         //Due to HTML5 being dogshit, we can't use is_ptr()
-		// Expect numeric texture ID for non html platforms
-		if (is_undefined(_texture))
-        || (__SCRIBBLE_ON_WEB && is_numeric(_texture))
+		if (is_numeric(_texture) || is_undefined(_texture))
 		{
             ++_i;
             continue;
@@ -232,7 +230,7 @@ function scribble_font_bake_shader(_source_font_name, _new_font_name, _shader, _
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.HEIGHT,      _glyph_count-1, SCRIBBLE_GLYPH.HEIGHT,      _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_HEIGHT, _glyph_count-1, SCRIBBLE_GLYPH.FONT_HEIGHT, _t_pad + _b_pad);
     ds_grid_add_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.SEPARATION,  _glyph_count-1, SCRIBBLE_GLYPH.SEPARATION,  _separation);
-    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture_id(_sprite, 0));
+    ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.TEXTURE,     _glyph_count-1, SCRIBBLE_GLYPH.TEXTURE,     __scribble_sprite_get_texture(_sprite, 0));
     ds_grid_set_region(_new_glyphs_grid, 0, SCRIBBLE_GLYPH.FONT_NAME,   _glyph_count-1, SCRIBBLE_GLYPH.FONT_NAME,   _new_font_name);
     
     //Figure out the new UVs using some bulk commands

--- a/scripts/scribble_font_bake_shadow/scribble_font_bake_shadow.gml
+++ b/scripts/scribble_font_bake_shadow/scribble_font_bake_shadow.gml
@@ -1,14 +1,14 @@
 // Feather disable all
 /// Creates a new font with an outline based on a given source font
 ///
-/// @param sourceFontName   Name, as a string, of the font to use as a basis for the effect
-/// @param newFontName      Name of the new font to create, as a string
-/// @param dX               
-/// @param dY               
-/// @param shadowColour     Colour of the shadow
-/// @param shadowAlpha      Alpha of the shadow
-/// @param separation       Additional separation to add between glyphs
-/// @param smooth           Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
+/// @param {String} sourceFontName                     Name, as a string, of the font to use as a basis for the effect
+/// @param {String} newFontName                        Name of the new font to create, as a string
+/// @param {Real} dx                                   The x direction of the drop shadow
+/// @param {Real} dy                                   The y direction of the drop shadow
+/// @param {Real.Int|Constant.Colour} shadowColour     Colour of the shadow
+/// @param {Real.Float} shadowAlpha                    Alpha of the shadow
+/// @param {Real} separation                           Additional separation to add between glyphs
+/// @param {Bool} smooth                               Whether or not to interpolate the outline. Set to <false> for pixel fonts, set to <true> for anti-aliased fonts
 
 function scribble_font_bake_shadow(_source_font_name, _new_font_name, _dx, _dy, _shadow_color, _shadow_alpha, _separation, _smooth)
 {

--- a/scripts/scribble_font_delete/scribble_font_delete.gml
+++ b/scripts/scribble_font_delete/scribble_font_delete.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param name
+/// @param {String} name
 
 function scribble_font_delete(_name)
 {

--- a/scripts/scribble_font_duplicate/scribble_font_duplicate.gml
+++ b/scripts/scribble_font_duplicate/scribble_font_duplicate.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param fontName
-/// @param newName
+/// @param {String} fontName
+/// @param {String} newName
 
 function scribble_font_duplicate(_old, _new)
 {

--- a/scripts/scribble_font_exists/scribble_font_exists.gml
+++ b/scripts/scribble_font_exists/scribble_font_exists.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param name
+/// @param {String} name
 
 function scribble_font_exists(_name)
 {

--- a/scripts/scribble_font_force_bilinear_filtering/scribble_font_force_bilinear_filtering.gml
+++ b/scripts/scribble_font_force_bilinear_filtering/scribble_font_force_bilinear_filtering.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 
-/// @param font
-/// @param state
+/// @param {String} fontName
+/// @param {Real.Int} state
 
 function scribble_font_force_bilinear_filtering(_font, _state)
 {

--- a/scripts/scribble_font_get_glyph_ranges/scribble_font_get_glyph_ranges.gml
+++ b/scripts/scribble_font_get_glyph_ranges/scribble_font_get_glyph_ranges.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param fontName
-/// @param [hex=false]
+/// @param {String} fontName
+/// @param {Bool} [hex=false]
 
 function scribble_font_get_glyph_ranges(_name, _hex = false)
 {

--- a/scripts/scribble_font_has_character/scribble_font_has_character.gml
+++ b/scripts/scribble_font_has_character/scribble_font_has_character.gml
@@ -2,8 +2,9 @@
 /// Tests to see if a font has the given character
 /// 
 /// Returns: Boolean, indicating whether the given character is found in the font
-/// @param fontName   The target font, as a string
-/// @param character  Character to test for, as a string
+/// @param {String} fontName   The target font, as a string
+/// @param {String} character  Character to test for, as a string
+/// @returns {Bool}
 
 function scribble_font_has_character(_font_name, _character)
 {

--- a/scripts/scribble_font_rename/scribble_font_rename.gml
+++ b/scripts/scribble_font_rename/scribble_font_rename.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param oldName
-/// @param newName
+/// @param {String} oldName
+/// @param {String} newName
 
 function scribble_font_rename(_old, _new)
 {

--- a/scripts/scribble_font_scale/scribble_font_scale.gml
+++ b/scripts/scribble_font_scale/scribble_font_scale.gml
@@ -2,8 +2,9 @@
 /// Scales a font's glyphs permanently across all future text elements
 /// 
 /// Returns: N/A (undefined)
-/// @param fontName  The target font, as a string
-/// @param scale     Scaling factor to apply
+/// @param {String} fontName  The target font, as a string
+/// @param {Real} scale     Scaling factor to apply
+/// @returns {Undefined}
 
 function scribble_font_scale(_font, _scale)
 {

--- a/scripts/scribble_font_set_default/scribble_font_set_default.gml
+++ b/scripts/scribble_font_set_default/scribble_font_set_default.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 /// Sets the default font to use for Scribble text elements
 /// 
-/// @param fontName   The name of the default Scribble font to use, as a string
+/// @param {String} fontName   The name of the default Scribble font to use, as a string
 
 function scribble_font_set_default(_font)
 {

--- a/scripts/scribble_font_set_halign_offset/scribble_font_set_halign_offset.gml
+++ b/scripts/scribble_font_set_halign_offset/scribble_font_set_halign_offset.gml
@@ -1,8 +1,8 @@
 /// Feather ignore all
 /// 
-/// @param font
-/// @param hAlign
-/// @param offset
+/// @param {String} fontName
+/// @param {Constant.HAlign} hAlign
+/// @param {Real} offset
 
 function scribble_font_set_halign_offset(_font, _halign, _offset)
 {

--- a/scripts/scribble_font_set_style_family/scribble_font_set_style_family.gml
+++ b/scripts/scribble_font_set_style_family/scribble_font_set_style_family.gml
@@ -2,10 +2,10 @@
 /// Associates four fonts together for use with [r] [b] [i] [bi] font tags
 /// Use <undefined> for any style you don't want to set a font for
 /// 
-/// @param regularFont     Name of font to use for the regular style
-/// @param boldFont        Name of font to use for the bold style
-/// @param italicFont      Name of font to use for the italic style
-/// @param boldItalicFont  Name of font to use for the bold-italic style
+/// @param {String} regularFont     Name of font to use for the regular style
+/// @param {String} boldFont        Name of font to use for the bold style
+/// @param {String} italicFont      Name of font to use for the italic style
+/// @param {String} boldItalicFont  Name of font to use for the bold-italic style
 
 function scribble_font_set_style_family(_r_font, _b_font, _i_font, _bi_font)
 {

--- a/scripts/scribble_font_set_valign_offset/scribble_font_set_valign_offset.gml
+++ b/scripts/scribble_font_set_valign_offset/scribble_font_set_valign_offset.gml
@@ -1,8 +1,8 @@
 /// Feather ignore all
 /// 
-/// @param font
-/// @param vAlign
-/// @param offset
+/// @param {String} fontName
+/// @param {Constant.VAlign} vAlign
+/// @param {Real} offset
 
 function scribble_font_set_valign_offset(_font, _valign, _offset)
 {

--- a/scripts/scribble_glyph_get/scribble_glyph_get.gml
+++ b/scripts/scribble_glyph_get/scribble_glyph_get.gml
@@ -1,9 +1,10 @@
 // Feather disable all
 /// Returns: Real-value for the specified property
-/// @param fontName     The target font, as a string
-/// @param character    Target character, as a string
-/// @param property     Property to return, see below
-/// 
+/// @param {String}                  fontName     The target font, as a string
+/// @param {String}                  character    Target character, as a string
+/// @param {Constant.SCRIBBLE_GLYPH} property     Property to return, see below
+/// @return {Any}
+
 /// Three properties are available:
 /// SCRIBBLE_GLYPH.X_OFFSET:   The relative x-offset to draw the glyph
 /// SCRIBBLE_GLYPH.Y_OFFSET:   The relative y-offset to draw the glyph

--- a/scripts/scribble_glyph_set/scribble_glyph_set.gml
+++ b/scripts/scribble_glyph_set/scribble_glyph_set.gml
@@ -2,12 +2,13 @@
 /// Modifies a particular value for a character in a font previously added to Scribble.
 /// 
 /// Returns: The new value of the property that was modified.
-/// @param fontName           The target font, as a string
-/// @param character          Target character, as a string
-/// @param property           Property to return, see below
-/// @param value              The value to set
-/// @param [relative=false]   Whether to add the new value to the existing value, or to overwrite the existing value. Defaults to false, overwriting the existing value
-/// 
+/// @param {String}                   fontName   The target font, as a string
+/// @param {String}                   character  Target character, as a string
+/// @param {Constant.SCRIBBLE_GLYPH}  property   Property to return, see below
+/// @param {Any}                      value      The value to set
+/// @param {Bool}                     relative   Whether to add the new value to the existing value, or to overwrite the existing value. Defaults to false, overwriting the existing value
+/// @return {any}
+
 /// Fonts can often be tricky to render correctly, and this script allows you to change certain properties.
 /// Properties can be adjusted at any time, but existing/cached Scribble text will not be updated to match new properties.
 /// 

--- a/scripts/scribble_is_text_element/scribble_is_text_element.gml
+++ b/scripts/scribble_is_text_element/scribble_is_text_element.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param value
+/// @param {Any} value
 
 function scribble_is_text_element(_value)
 {

--- a/scripts/scribble_kerning_pair_get/scribble_kerning_pair_get.gml
+++ b/scripts/scribble_kerning_pair_get/scribble_kerning_pair_get.gml
@@ -2,9 +2,9 @@
 /// Returns the separation offset between two characters
 /// 
 /// Returns: The new value of the property that was modified.
-/// @param fontName           The target font, as a string
-/// @param firstChar          First character in the pair, as a string
-/// @param secondChar         Second character in the pair, as a string
+/// @param {String} fontName           The target font, as a string
+/// @param {String} firstChar          First character in the pair, as a string
+/// @param {String} secondChar         Second character in the pair, as a string
 
 function scribble_kerning_pair_get(_font, _first_char, _second_char)
 {

--- a/scripts/scribble_kerning_pair_set/scribble_kerning_pair_set.gml
+++ b/scripts/scribble_kerning_pair_set/scribble_kerning_pair_set.gml
@@ -2,11 +2,11 @@
 /// Adjusts the separation offset between two characters
 /// 
 /// Returns: The new value of the property that was modified.
-/// @param fontName           The target font, as a string
-/// @param firstChar          First character in the pair, as a string
-/// @param secondChar         Second character in the pair, as a string
-/// @param value              The value to set
-/// @param [relative=false]   Whether to add the new value to the existing value, or to overwrite the existing value. Defaults to false, overwriting the existing value
+/// @param {String} fontName           The target font, as a string
+/// @param {String} firstChar          First character in the pair, as a string
+/// @param {String} secondChar         Second character in the pair, as a string
+/// @param {Real} value              The value to set
+/// @param {Bool} [relative=false]   Whether to add the new value to the existing value, or to overwrite the existing value. Defaults to false, overwriting the existing value
 
 function scribble_kerning_pair_set(_font, _first_char, _second_char, _value, _relative = false)
 {

--- a/scripts/scribble_markdown_format/scribble_markdown_format.gml
+++ b/scripts/scribble_markdown_format/scribble_markdown_format.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param string
+/// @param {String} string
 
 #macro __SCRIBBLE_MARKDOWN_UPDATE_NEXT_VALUE  _next_value = buffer_peek(_buffer, buffer_tell(_buffer)-1, buffer_u8);
 

--- a/scripts/scribble_markdown_set_styles/scribble_markdown_set_styles.gml
+++ b/scripts/scribble_markdown_set_styles/scribble_markdown_set_styles.gml
@@ -1,6 +1,6 @@
 // Feather disable all
-/// @param styleStruct
-/// @param [fastMode=false]
+/// @param {Struct} styleStruct
+/// @param {Bool} [fastMode=false]
 
 function scribble_markdown_set_styles(_root_struct, _fast_mode = false)
 {

--- a/scripts/scribble_msdf_thickness_offset/scribble_msdf_thickness_offset.gml
+++ b/scripts/scribble_msdf_thickness_offset/scribble_msdf_thickness_offset.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param offset
+/// @param {Real} offset
 
 function scribble_msdf_thickness_offset(_offset)
 {

--- a/scripts/scribble_rgb_to_bgr/scribble_rgb_to_bgr.gml
+++ b/scripts/scribble_rgb_to_bgr/scribble_rgb_to_bgr.gml
@@ -1,7 +1,7 @@
 // Feather disable all
 /// Converts an RGB colour code (the industry standard) to GameMaker's native BGR format
 /// 
-/// @param RGB   24-bit industry standard RGB colour integer
+/// @param {Real.Int|Constant.Colour} RGB   24-bit industry standard RGB colour integer
 
 function scribble_rgb_to_bgr(_rgb)
 {

--- a/scripts/scribble_super_create/scribble_super_create.gml
+++ b/scripts/scribble_super_create/scribble_super_create.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param newFontName
+/// @param {String} newFontName
 
 function scribble_super_create(_name)
 {

--- a/scripts/scribble_super_glyph_copy/scribble_super_glyph_copy.gml
+++ b/scripts/scribble_super_glyph_copy/scribble_super_glyph_copy.gml
@@ -1,9 +1,9 @@
 // Feather disable all
-/// @param target
-/// @param source
-/// @param overwrite
-/// @param glyphs
-/// @param [glyphs]...
+/// @param {String} target		Name of the superfont to add glyphs to
+/// @param {String} source		Name of the font to add glyphs from
+/// @param {Bool} overwrite		Whether to overwrite existing glyphs in the target font with new glyphs from the source font
+/// @param {Any} glyphsSet...	The glyph, or glyphs, to add.
+/// @param {Any} glyphs...		Additional glyph, or glyphs, to add
 
 function scribble_super_glyph_copy(_target, _source, _overwrite)
 {

--- a/scripts/scribble_super_glyph_copy_all/scribble_super_glyph_copy_all.gml
+++ b/scripts/scribble_super_glyph_copy_all/scribble_super_glyph_copy_all.gml
@@ -1,7 +1,7 @@
 // Feather disable all
-/// @param targetFontName
-/// @param sourceFontName
-/// @param overwrite
+/// @param {String} targetFontName
+/// @param {String} sourceFontName
+/// @param {Bool} overwrite
 
 function scribble_super_glyph_copy_all(_target, _source, _overwrite)
 {

--- a/scripts/scribble_typist/scribble_typist.gml
+++ b/scripts/scribble_typist/scribble_typist.gml
@@ -1,5 +1,5 @@
 // Feather disable all
-/// @param [perLine=false]
+/// @param {Bool} [perLine=false]
 
 function scribble_typist(_per_line = false)
 {

--- a/scripts/scribble_typists_add_event/scribble_typists_add_event.gml
+++ b/scripts/scribble_typists_add_event/scribble_typists_add_event.gml
@@ -1,8 +1,8 @@
 // Feather disable all
 /// Defines an event - a script that can be executed (with parameters) by an in-line command tag
 /// 
-/// @param name              Name of the new formatting tag to add e.g. portrait adds the tag [portrait] for use
-/// @param function/method   Function or method to execute
+/// @param {String} name              Name of the new formatting tag to add e.g. portrait adds the tag [portrait] for use
+/// @param {Function} function/method   Function or method to execute
 
 function scribble_typists_add_event(_name, _function)
 {

--- a/scripts/scribble_whitelist_sound/scribble_whitelist_sound.gml
+++ b/scripts/scribble_whitelist_sound/scribble_whitelist_sound.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param wound
+/// @param {Asset.GMSound} wound
 
 function scribble_whitelist_sound(_wound)
 {

--- a/scripts/scribble_whitelist_sprite/scribble_whitelist_sprite.gml
+++ b/scripts/scribble_whitelist_sprite/scribble_whitelist_sprite.gml
@@ -1,6 +1,6 @@
 // Feather disable all
 
-/// @param sprite
+/// @param {Asset.GMSprite} sprite
 
 function scribble_whitelist_sprite(_sprite)
 {

--- a/scripts/string_height_scribble/string_height_scribble.gml
+++ b/scripts/string_height_scribble/string_height_scribble.gml
@@ -3,7 +3,7 @@
 /// 
 /// **Please do not use this function in conjunction with string_copy()**
 /// 
-/// @param string    The string to draw
+/// @param {String} string    The string to draw
 
 function string_height_scribble(_string)
 {

--- a/scripts/string_height_scribble_ext/string_height_scribble_ext.gml
+++ b/scripts/string_height_scribble_ext/string_height_scribble_ext.gml
@@ -3,8 +3,8 @@
 /// 
 /// **Please do not use this function in conjunction with string_copy()**
 /// 
-/// @param string  The string to draw
-/// @param width   The maximum width in pixels of the string before a line break
+/// @param {String} string  The string to draw
+/// @param {Real} width   The maximum width in pixels of the string before a line break
 
 function string_height_scribble_ext(_string, _width)
 {

--- a/scripts/string_length_scribble/string_length_scribble.gml
+++ b/scripts/string_length_scribble/string_length_scribble.gml
@@ -3,7 +3,7 @@
 /// 
 /// **Please do not use this function in conjunction with string_copy()**
 /// 
-/// @param string    The string to draw
+/// @param {String} string    The string to draw
 
 function string_length_scribble(_string)
 {

--- a/scripts/string_width_scribble/string_width_scribble.gml
+++ b/scripts/string_width_scribble/string_width_scribble.gml
@@ -3,7 +3,7 @@
 /// 
 /// **Please do not use this function in conjunction with string_copy()**
 /// 
-/// @param string    The string to draw
+/// @param {String} string    The string to draw
 
 function string_width_scribble(_string)
 {

--- a/scripts/string_width_scribble_ext/string_width_scribble_ext.gml
+++ b/scripts/string_width_scribble_ext/string_width_scribble_ext.gml
@@ -3,8 +3,8 @@
 /// 
 /// **Please do not use this function in conjunction with string_copy()**
 /// 
-/// @param string  The string to draw
-/// @param width   The maximum width in pixels of the string before a line break
+/// @param {String} string  The string to draw
+/// @param {Real} width   The maximum width in pixels of the string before a line break
 
 function string_width_scribble_ext(_string, _width)
 {


### PR DESCRIPTION
Many of the user facing classes like element and typist were missing docs for their non internal functions. So i took some time today to supply those to hopefully fix errors like this:
![image](https://github.com/user-attachments/assets/a679ed63-60cb-498c-bc5a-4cb35588a393)

Additionally I improved many of the existing jsDocs to implicitly include the type.

I was unsure if you were making use of an automated jsDoc -> wiki, so I did my best to leave things untouched unless they were actively introducing bugs, for instance having an additional descriptions after a parameter, with out a return defined would append the description to the parameter's description. 