### PR TITLE
fixed a crash when many `…` are used in a supplied string.

### DIFF
--- a/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
+++ b/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
@@ -1456,7 +1456,13 @@ function __scribble_gen_2_parser()
             }
             else if (SCRIBBLE_UNDO_UNICODE_SUBSTITUTIONS && (_glyph_ord == 0x2026)) //Replace ellipsis … with three full stops (periods)
             {
-                //Figure out how much we need to copy and if we need to resize the target buffer
+                //expand the glyph grid by 2 additional slots to account for a single glyph of `…` being converted into 3 glyphs of `...`
+				var _element_expected_text_length = ds_grid_width(_glyph_grid);
+				ds_grid_resize(_glyph_grid,     _element_expected_text_length + 2, __SCRIBBLE_GEN_GLYPH.__SIZE);
+			    ds_grid_resize(_word_grid,      _element_expected_text_length + 2, __SCRIBBLE_GEN_GLYPH.__SIZE);
+				ds_grid_resize(_vbuff_pos_grid, _element_expected_text_length + 2, __SCRIBBLE_GEN_GLYPH.__SIZE);
+				
+				//Figure out how much we need to copy and if we need to resize the target buffer
                 var _copy_size = _buffer_length - buffer_tell(_string_buffer);
                 
                 _buffer_length = 3 + _copy_size;


### PR DESCRIPTION
There has been a long standing bug in which a very long string, with many uses of ellipsis `…` will result in a grid out of bounds error, this fixes that issue specifically for ellipsis, but there is also the same errors when handling Zero Width Joiners ZWJ, as GM's native string length doesn't account for this.

Ultimately it would be better practice to over size the grid to the buffer size, then shrink it down to the index after the fact, meaning there will only ever be 2 grid resizes instead of possibly many, this also gives the added benefit that we don't rely on string operations as much. Though before offering such an implementation this should be discussed and considered how it will effect these other grids.

This was a direct patch specifically for SamTHK on discord, needs further testing, but users can simply use `...` if they need to for now. Which is what was suggested to Sam