### PR TITLE
glyph count boundary check

### DIFF
--- a/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
+++ b/scripts/__scribble_gen_2_parser/__scribble_gen_2_parser.gml
@@ -54,7 +54,7 @@
                                           if (SCRIBBLE_USE_KERNING)\
                                           {\
                                               var _kerning = _font_kerning_map[? ((_glyph_write & 0xFFFF) << 16) | (_glyph_prev & 0xFFFF)];\
-                                              if (_kerning != undefined) _glyph_grid[# _glyph_count-1, __SCRIBBLE_GEN_GLYPH.__SEPARATION] += _kerning*_glyph_grid[# _glyph_count-1, __SCRIBBLE_GEN_GLYPH.__SCALE];\
+                                              if (_kerning != undefined && _glyph_count > 0) _glyph_grid[# _glyph_count-1, __SCRIBBLE_GEN_GLYPH.__SEPARATION] += _kerning*_glyph_grid[# _glyph_count-1, __SCRIBBLE_GEN_GLYPH.__SCALE];\
                                           }\
                                           ;\
                                           if (SCRIBBLE_USE_FONT_ALIGNMENT_OFFSETS)\


### PR DESCRIPTION
Hey,

just came upon this crash, don't know, how exactly it happened, but you do a grid[# glyph_count - 1, ...].
If, for whatever reason, glyph_count happens to be zero here, you access grid [# -1,...], which crashes the game.

it just happened here - the fix is just a "&& _glyph_count > 0" to make sure, this doesn't happen. Boundary checks are always a good idea ;-)

cheers Gris