### PR TITLE
Mark matrix as dirty when z coordinate changes

### DIFF
--- a/scripts/__ScribbleClassElementParent/__ScribbleClassElementParent.gml
+++ b/scripts/__ScribbleClassElementParent/__ScribbleClassElementParent.gml
@@ -1741,7 +1741,11 @@ function __ScribbleClassElementParent(_text) constructor
     
     static z = function(_z)
     {
-        __z = _z;
+        if (__z != _z)
+        {
+            __z = _z;
+            __matrixDirty = true;
+        }
         
         return self;
     }


### PR DESCRIPTION
if you only change Z but not X or Y coords, it won't be marked as dirteyyy